### PR TITLE
Missing WHERE ID=`` in UPDATE

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func TestGORM(t *testing.T) {
 	//user4 not inserted
 
 	if err := DB.Model(&user4).Updates(map[string]interface{}{"name": "test name"}).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+		t.Logf("Failed, got error: %v", err)
 	}
 	var result []User
 	DB.Find(&result)

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,20 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user1 := User{Name: "jinzhu 1"}
+	user2 := User{Name: "jinzhu 2"}
+	user3 := User{Name: "jinzhu 3"}
+	user4 := User{Name: "jinzhu 4"}
 
-	DB.Create(&user)
+	DB.Create(&user1)
+	DB.Create(&user2)
+	DB.Create(&user3)
+	//user4 not inserted
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Model(&user4).Updates(map[string]interface{}{"name": "test name"}).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	var result []User
+	DB.Find(&result)
+	t.Logf("Result: %v", result)
 }


### PR DESCRIPTION
Related to: https://github.com/go-gorm/gorm/issues/3097

## Explain your user case and expected results

The missing ID in the WHERE statement is reaching the DB engine in v1.9.13, however here in (v0.2.15) it's correctly handled.