### PR TITLE
test foreign key

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,17 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Bugs struct {
+	ID     int64
+	Status BugStatus `gorm:"ForeignKey:Status;References:Status;Constraint:OnUpdate:CASCADE"`
+}
+
+type BugStatus struct {
+	Status string `gorm:"PrimaryKey;type:varchar(22)"`
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.AutoMigrate(new(BugStatus), new(Bugs)); err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
```sql

CREATE TABLE BugStatus (
  status  VARCHAR(20) PRIMARY KEY
);

INSERT INTO BugStatus (status) VALUES ('NEW'), ('IN PROGRESS'), ('FIXED');

CREATE TABLE Bugs (
  -- other columns
  status  VARCHAR(20),
  FOREIGN KEY (status) REFERENCES BugStatus(status)
    ON UPDATE CASCADE
);
```

```go
type Bugs struct {
	ID     int64
	Status BugStatus `gorm:"ForeignKey:Status;References:Status;Constraint:OnUpdate:CASCADE"`
}

type BugStatus struct {
	Status string `gorm:"PrimaryKey;type:varchar(22)"`
}
```

怎样可以还原上面的 SQL 语句？我试了一下上面的结构，在 Mysql 中自动生成语句出错，SQL 输出为：
```
CREATE TABLE `bug_statuses` (`status` ,PRIMARY KEY (`status`),CONSTRAINT `fk_bugs_status` FOREIGN KEY (`status`) REFERENCES `bugs`(``) ON UPDATE CASCADE)
```
status 的类型消失， REFERENCES `bugs`(``) 字段消失
