### PR TITLE
Joins生成2次left join导致 ambiguous column name

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -14,7 +16,36 @@ func TestGORM(t *testing.T) {
 	DB.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if doc, count, err := result.GetPage(DB, 10, 1); err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	} else {
+		t.Log(doc, count)
 	}
+}
+
+type UserPage struct {
+	User
+	CompanyName string `gorm:"-" json:"companyName"`
+}
+
+func (User) TableName() string {
+	return "user"
+}
+
+func (Company) TableName() string {
+	return "company"
+}
+
+func (e *User) GetPage(db *gorm.DB, pageSize int, pageIndex int) ([]UserPage, int64, error) {
+	var doc []UserPage
+	table := db.Select("user.*,company.name company_name").Table("user")
+	table = table.Joins("left join company on user.company_id = company.id")
+
+	var count int64
+
+	if err := table.Offset((pageIndex - 1) * pageSize).Limit(pageSize).Find(&doc).Error; err != nil {
+		return nil, 0, err
+	}
+	table.Count(&count)
+	return doc, count, nil
 }

--- a/models.go
+++ b/models.go
@@ -16,11 +16,11 @@ type User struct {
 	Name      string
 	Age       uint
 	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
+	Account   Account `gorm:"foreignKey:UserID"`
+	Pets      []*Pet  `gorm:"foreignKey:UserID"`
+	Toys      []Toy   `gorm:"polymorphic:Owner"`
 	CompanyID *int
-	Company   Company
+	Company   Company `gorm:"foreignKey:CompanyID"`
 	ManagerID *uint
 	Manager   *User
 	Team      []User     `gorm:"foreignkey:ManagerID"`


### PR DESCRIPTION
## Explain your user case and expected results
2020/07/13 13:24:14 /home/vscode/workspace/playground/main_test.go:52 ambiguous column name: company.id
[0.069ms] [rows:0] SELECT count(1) FROM user left join company on user.company_id = company.id left join company on user.company_id = company.id WHERE user.deleted_at IS NULL AND user.deleted_at IS NULL LIMIT 10