### PR TITLE
Scan into composite model

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "host=localhost user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.14
 
 require (
 	github.com/jinzhu/now v1.1.1
-	gorm.io/driver/mysql v0.2.9
-	gorm.io/driver/postgres v0.2.5
+	gorm.io/driver/mysql v0.3.1
+	gorm.io/driver/postgres v0.2.6
 	gorm.io/driver/sqlite v1.0.8
-	gorm.io/driver/sqlserver v0.2.4
+	gorm.io/driver/sqlserver v0.2.5
 	gorm.io/gorm v0.2.20
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,90 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	type Thing1 struct {
+		gorm.Model
+		Name string `gorm:"size:20"`
+		One int
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	type Thing2 struct {
+		gorm.Model
+		Name string `gorm:"size:20"`
+		Two int
+	}
+
+	type Thing3 struct {
+		gorm.Model
+		Name string `gorm:"size:20"`
+		Three int
+	}
+
+	type Composite struct {
+		*Thing1
+		*Thing2
+		*Thing3
+	}
+
+	if err := DB.AutoMigrate(&Thing1{}, &Thing2{}, &Thing3{}); err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	DB.Create(&Thing1{
+		Name:  "Thing 1",
+		One:   1,
+	})
+	DB.Create(&Thing2{
+		Name:  "Thing 2",
+		Two:   2,
+	})
+	DB.Create(&Thing3{
+		Name:  "Thing 3",
+		Three:   3,
+	})
+
+	t1 := new(Thing1)
+	t2 := new(Thing2)
+	t3 := new(Thing3)
+
+	DB.First(t1)
+	DB.First(t2)
+	DB.First(t3)
+
+	c := new(Composite)
+
+	if err := DB.Raw("SELECT thing1.*, thing2.*, thing3.* FROM thing1 " +
+		"INNER JOIN thing2 ON thing1.id = thing2.id " +
+		"INNER JOIN thing3 ON thing1.id = thing3.id " +
+		"WHERE thing1.id = 1").Scan(c).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if t1.ID != c.Thing1.ID {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t1.ID, c.Thing1.ID)
+	}
+	if t1.Name != c.Thing1.Name {
+		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t1.Name, c.Thing1.Name)
+	}
+	if t1.CreatedAt != c.Thing1.CreatedAt {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t1.CreatedAt, c.Thing1.CreatedAt)
+	}
+	if t2.ID != c.Thing2.ID {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t2.ID, c.Thing2.ID)
+	}
+	if t2.Name != c.Thing2.Name {
+		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t2.Name, c.Thing2.Name)
+	}
+	if t2.CreatedAt != c.Thing2.CreatedAt {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t2.CreatedAt, c.Thing2.CreatedAt)
+	}
+	if t3.ID != c.Thing3.ID {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t3.ID, c.Thing3.ID)
+	}
+	if t3.Name != c.Thing3.Name {
+		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t3.Name, c.Thing3.Name)
+	}
+	if t3.CreatedAt != c.Thing3.CreatedAt {
+		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -77,24 +77,33 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t1.Name, c.Thing1.Name)
 	}
 	if t1.CreatedAt != c.Thing1.CreatedAt {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t1.CreatedAt, c.Thing1.CreatedAt)
+		t.Errorf("Thing 1 Created. Wanted: %v - Got: %v", t1.CreatedAt, c.Thing1.CreatedAt)
+	}
+	if t1.One != c.Thing1.One {
+		t.Errorf("Thing 1 One. Wanted: %v - Got: %v", t1.One, c.Thing1.One)
 	}
 	if t2.ID != c.Thing2.ID {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t2.ID, c.Thing2.ID)
+		t.Errorf("Thing 2 ID. Wanted: %v - Got: %v", t2.ID, c.Thing2.ID)
 	}
 	if t2.Name != c.Thing2.Name {
-		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t2.Name, c.Thing2.Name)
+		t.Errorf("Thing 2 Name. Wanted: %v - Got: %v", t2.Name, c.Thing2.Name)
 	}
 	if t2.CreatedAt != c.Thing2.CreatedAt {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t2.CreatedAt, c.Thing2.CreatedAt)
+		t.Errorf("Thing 2 Created. Wanted: %v - Got: %v", t2.CreatedAt, c.Thing2.CreatedAt)
+	}
+	if t2.Two != c.Thing2.Two {
+		t.Errorf("Thing 2 Two. Wanted: %v - Got: %v", t2.Two, c.Thing2.Two)
 	}
 	if t3.ID != c.Thing3.ID {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t3.ID, c.Thing3.ID)
+		t.Errorf("Thing 3 ID. Wanted: %v - Got: %v", t3.ID, c.Thing3.ID)
 	}
 	if t3.Name != c.Thing3.Name {
-		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t3.Name, c.Thing3.Name)
+		t.Errorf("Thing 3 Name. Wanted: %v - Got: %v", t3.Name, c.Thing3.Name)
 	}
 	if t3.CreatedAt != c.Thing3.CreatedAt {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
+		t.Errorf("Thing 3 Created. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
+	}
+	if t3.Three != c.Thing3.Three {
+		t.Errorf("Thing 3 Three. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"gorm.io/gorm"
 	"testing"
 )
 
@@ -10,34 +9,21 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
+	user := User{Name: "jinzhu"}
 
-	type Airport struct {
-		gorm.Model
-		Uuid string `gorm:"type:char(22);not null;uniqueIndex"`
-		CompanyId uint32 `gorm:"not null;uniqueIndex:COMPANY_IATA,COMPANY_ICAO"`
-		IataAirportCode string `gorm:"type:char(3);uniqueIndex:COMPANY_IATA"`
-		IcaoAirportCode string `gorm:"type:char(4);uniqueIndex:COMPANY_ICAO"`
-	}
+	DB.Create(&user)
 
-	if err := DB.AutoMigrate(&Airport{}); err != nil {
+	var c int64
+
+	if err := DB.Table("users").Where("name = ?", "jinzhu").Select("name").Count(&c); err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	port := &Airport{
-		Uuid:            "4MxjS55RAivKy0edVtZurH",
-		CompanyId:       1,
-		IataAirportCode: "PVG",
-		IcaoAirportCode: "ZSPD",
-	}
-
-	if err := DB.Create(port).Error; err != nil {
+	if err := DB.Table("users").Where("name = ?", "jinzhu").Count(&c); err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	port.Uuid = "3pqmAIxhHGb7V0rZ2Egv1X"
-	port.CompanyId = 2
-
-	if err := DB.Create(port).Error; err != nil {
+	if err := DB.Table("users").Count(&c); err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"testing"
-
 	"gorm.io/gorm"
+	"testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -12,98 +11,33 @@ import (
 
 func TestGORM(t *testing.T) {
 
-	type Thing1 struct {
+	type Airport struct {
 		gorm.Model
-		Name string `gorm:"size:20"`
-		One int
+		Uuid string `gorm:"type:char(22);not null;uniqueIndex"`
+		CompanyId uint32 `gorm:"not null;uniqueIndex:COMPANY_IATA,COMPANY_ICAO"`
+		IataAirportCode string `gorm:"type:char(3);uniqueIndex:COMPANY_IATA"`
+		IcaoAirportCode string `gorm:"type:char(4);uniqueIndex:COMPANY_ICAO"`
 	}
 
-	type Thing2 struct {
-		gorm.Model
-		Name string `gorm:"size:20"`
-		Two int
-	}
-
-	type Thing3 struct {
-		gorm.Model
-		Name string `gorm:"size:20"`
-		Three int
-	}
-
-	type Composite struct {
-		*Thing1
-		*Thing2
-		*Thing3
-	}
-
-	if err := DB.AutoMigrate(&Thing1{}, &Thing2{}, &Thing3{}); err != nil {
+	if err := DB.AutoMigrate(&Airport{}); err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	DB.Create(&Thing1{
-		Name:  "Thing 1",
-		One:   1,
-	})
-	DB.Create(&Thing2{
-		Name:  "Thing 2",
-		Two:   2,
-	})
-	DB.Create(&Thing3{
-		Name:  "Thing 3",
-		Three:   3,
-	})
+	port := &Airport{
+		Uuid:            "4MxjS55RAivKy0edVtZurH",
+		CompanyId:       1,
+		IataAirportCode: "PVG",
+		IcaoAirportCode: "ZSPD",
+	}
 
-	t1 := new(Thing1)
-	t2 := new(Thing2)
-	t3 := new(Thing3)
-
-	DB.First(t1)
-	DB.First(t2)
-	DB.First(t3)
-
-	c := new(Composite)
-
-	if err := DB.Raw("SELECT thing1.*, thing2.*, thing3.* FROM thing1 " +
-		"INNER JOIN thing2 ON thing1.id = thing2.id " +
-		"INNER JOIN thing3 ON thing1.id = thing3.id " +
-		"WHERE thing1.id = 1").Scan(c).Error; err != nil {
+	if err := DB.Create(port).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	if t1.ID != c.Thing1.ID {
-		t.Errorf("Thing 1 ID. Wanted: %v - Got: %v", t1.ID, c.Thing1.ID)
-	}
-	if t1.Name != c.Thing1.Name {
-		t.Errorf("Thing 1 Name. Wanted: %v - Got: %v", t1.Name, c.Thing1.Name)
-	}
-	if t1.CreatedAt != c.Thing1.CreatedAt {
-		t.Errorf("Thing 1 Created. Wanted: %v - Got: %v", t1.CreatedAt, c.Thing1.CreatedAt)
-	}
-	if t1.One != c.Thing1.One {
-		t.Errorf("Thing 1 One. Wanted: %v - Got: %v", t1.One, c.Thing1.One)
-	}
-	if t2.ID != c.Thing2.ID {
-		t.Errorf("Thing 2 ID. Wanted: %v - Got: %v", t2.ID, c.Thing2.ID)
-	}
-	if t2.Name != c.Thing2.Name {
-		t.Errorf("Thing 2 Name. Wanted: %v - Got: %v", t2.Name, c.Thing2.Name)
-	}
-	if t2.CreatedAt != c.Thing2.CreatedAt {
-		t.Errorf("Thing 2 Created. Wanted: %v - Got: %v", t2.CreatedAt, c.Thing2.CreatedAt)
-	}
-	if t2.Two != c.Thing2.Two {
-		t.Errorf("Thing 2 Two. Wanted: %v - Got: %v", t2.Two, c.Thing2.Two)
-	}
-	if t3.ID != c.Thing3.ID {
-		t.Errorf("Thing 3 ID. Wanted: %v - Got: %v", t3.ID, c.Thing3.ID)
-	}
-	if t3.Name != c.Thing3.Name {
-		t.Errorf("Thing 3 Name. Wanted: %v - Got: %v", t3.Name, c.Thing3.Name)
-	}
-	if t3.CreatedAt != c.Thing3.CreatedAt {
-		t.Errorf("Thing 3 Created. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
-	}
-	if t3.Three != c.Thing3.Three {
-		t.Errorf("Thing 3 Three. Wanted: %v - Got: %v", t3.CreatedAt, c.Thing3.CreatedAt)
+	port.Uuid = "3pqmAIxhHGb7V0rZ2Egv1X"
+	port.CompanyId = 2
+
+	if err := DB.Create(port).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
Scanning join results into a composite model fails where structs share filed names.

In v1, Scanning would unmarshal correctly into each struct provided the order in the composite struct matched the order of the selects.

This behavior is broken in v2.
