### PR TITLE
Many2Many Associations panic with UUID primary key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_PASSWORD=gorm
       - MYSQL_RANDOM_ROOT_PASSWORD="yes"
   postgres:
-    image: 'postgres:latest'
+    image: 'postgres:12-alpine'
     ports:
       - 9920:5432
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_PASSWORD=gorm
       - MYSQL_RANDOM_ROOT_PASSWORD="yes"
   postgres:
-    image: 'postgres:12-alpine'
+    image: 'postgres:latest'
     ports:
       - 9920:5432
     environment:
@@ -29,4 +29,3 @@ services:
       - MSSQL_DB=gorm
       - MSSQL_USER=gorm
       - MSSQL_PASSWORD=LoremIpsum86
-

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module gorm.io/playground
 go 1.14
 
 require (
-	github.com/jinzhu/now v1.1.1
-	gorm.io/driver/mysql v0.2.9
-	gorm.io/driver/postgres v0.2.5
+	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/google/uuid v1.1.1
+	gorm.io/driver/mysql v0.3.0
+	gorm.io/driver/postgres v0.2.6
 	gorm.io/driver/sqlite v1.0.8
 	gorm.io/driver/sqlserver v0.2.4
-	gorm.io/gorm v0.2.20
+	gorm.io/gorm v0.2.23
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,36 @@ package main
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Post struct {
+	ID         uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
+	Title      string
+	Categories []*Category `gorm:"Many2Many:posts_categories"`
+}
+
+type Category struct {
+	ID    uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
+	Title string
+	Posts []*Post `gorm:"Many2Many:posts_categories"`
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	post := Post{
+		Title: "Hello World",
+		Categories: []*Category{
+			{Title: "Coding"},
+			{Title: "Golang"},
+		},
+	}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Create(&post).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
 
 type Post struct {
 	ID         uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`


### PR DESCRIPTION
## Explain your user case and expected results

When creating or appending associations with PostgreSQL UUID primary keys.
I also tried using a string Go type for the UUID primary key GO type.

it always panics with the following error:

```sh
[2.360ms] [rows:2] INSERT INTO "categories" ("title") VALUES ('Coding'),('Golang') ON CONFLICT DO NOTHING RETURNING "id"
--- FAIL: TestGORM (0.02s)
panic: reflect: slice index out of range [recovered]
        panic: reflect: slice index out of range

goroutine 18 [running]:
testing.tRunner.func1.1(0xd0ed00, 0xeb9780)
        /usr/lib/go-1.14/src/testing/testing.go:940 +0x421
testing.tRunner.func1(0xc0000a0360)
        /usr/lib/go-1.14/src/testing/testing.go:943 +0x600
panic(0xd0ed00, 0xeb9780)
        /usr/lib/go-1.14/src/runtime/panic.go:975 +0x3e3
reflect.Value.Index(0xc000213e40, 0xc0002301c0, 0x97, 0x2, 0xc0007000a0, 0x191, 0x196)
        /usr/lib/go-1.14/src/reflect/value.go:939 +0x565
gorm.io/gorm/callbacks.CreateWithReturning(0xc0004dc0f0)
        ~/playground/gorm/callbacks/create.go:153 +0xa08
gorm.io/gorm.(*processor).Execute(0xc000021e00, 0xc0004dc0f0)
        ~/playground/gorm/callbacks.go:100 +0x1a0
gorm.io/gorm.(*DB).Create(0xc0004dc0f0, 0xc000213e40, 0xc0002301c0, 0x1)
        ~/playground/gorm/finisher_api.go:18 +0x13a
gorm.io/gorm/callbacks.SaveAfterAssociations(0xc0006ce990)
        ~/playground/gorm/callbacks/associations.go:295 +0x2b65
gorm.io/gorm.(*processor).Execute(0xc000021e00, 0xc0006ce990)
        ~/playground/gorm/callbacks.go:100 +0x1a0
gorm.io/gorm.(*DB).Create(0xc00020a240, 0xcfbe40, 0xc000213c00, 0x1368c45)
        ~/playground/gorm/finisher_api.go:18 +0x13a
gorm.io/playground.TestGORM(0xc0000a0360)
        ~/playground/main_test.go:34 +0x2d4
testing.tRunner(0xc0000a0360, 0xde8478)
        /usr/lib/go-1.14/src/testing/testing.go:991 +0x1ec
created by testing.(*T).Run
        /usr/lib/go-1.14/src/testing/testing.go:1042 +0x661
FAIL    gorm.io/playground      2.235s
FAIL
```

Expecting a successful save.