### PR TITLE
Fixing running PostgreSQL locally

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":


### PR DESCRIPTION
This is a PR for the playground itself. Without this change, running `master` branch locally fail for me with:

```
[error] failed to initialize database, got error failed to connect to `host=/tmp user=gorm database=gorm`: dial error (dial unix /tmp/.s.PGSQL.9920: connect: no such file or directory)
2020/08/05 21:41:25 failed to connect database, got error failed to connect to `host=/tmp user=gorm database=gorm`: dial error (dial unix /tmp/.s.PGSQL.9920: connect: no such file or directory)
```