### PR TITLE
Surprising results

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,17 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	err := DB.Where(&User{Name: "foobar", Age: 32}).Updates(map[string]interface{}{
+		"Active": true,
+	}).Error
+	if  err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err = DB.Model(&User{Name: "foobar", Age: 32}).Updates(map[string]interface{}{
+		"Active": true,
+	}).Error
+	if  err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
It is surprising that the correct syntax for the simple update query is:

```
DB.Model(&User{}).Where(&User{Name: "foobar", Age: 32}).Updates(map[string]interface{}{"Active": true})
```

Where ideally the following two should work as well:

```
DB.Where(&User{Name: "foobar", Age: 32}).Updates(map[string]interface{}{"Active": true})
DB.Model(&User{Name: "foobar", Age: 32}).Updates(map[string]interface{}{"Active": true})
```

The issue is also that the error message for the first one is misleading:

```
TestGORM: main_test.go:16: Failed, got error: unsupported data type: map[Active:true]
```

For the second one it is better, but still, why necessary:

```
TestGORM: main_test.go:23: Failed, got error: WHERE conditions required
```