### PR TITLE
PR for issue

### DIFF
--- a/db.go
+++ b/db.go
@@ -77,7 +77,10 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	} else if debug == "false" {
 		db.Logger = db.Logger.LogMode(logger.Silent)
 	}
-
+	sqlDB, err := DB.DB()
+	sqlDB.SetMaxOpenConns(100)
+	sqlDB.SetMaxIdleConns(100)
+	sqlDB.SetConnMaxLifetime(5 * time.Minute)
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	OpenTestConnection()
+	GetUserByEmail("test@gmail.com")
+}

--- a/models.go
+++ b/models.go
@@ -14,6 +14,7 @@ import (
 type User struct {
 	gorm.Model
 	Name      string
+	Email      string
 	Age       uint
 	Birthday  *time.Time
 	Account   Account
@@ -57,4 +58,12 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+func GetUserByEmail(email string) (*User, error) {
+	var user User
+	if err := DB.Where(&User{Email: email}).First(&user).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil //nolint:wsl
 }


### PR DESCRIPTION
I tried to implement GormV2 with SetMaxOpenConns and SetMaxIdleConns using following code

```go
var DB *gorm.DB

func SetupDB() (*gorm.DB, error) {
	//nolint:wsl,lll
	var err error //nolint:wsl
	LoadDBConfig()
	connectionString := ""
	if DB != nil {
		return DB, nil
	}
	switch DBConfig.DB_Driver {
	case "postgres":
		connectionString = fmt.Sprintf("host=%s port=%d user=%s dbname=%s password=%s", DBConfig.DB_Host, DBConfig.DB_Port, DBConfig.DB_User, DBConfig.DB_Name, DBConfig.DB_Pass)
		DB, err = gorm.Open(postgres.Open(connectionString), &gorm.Config{})

	default:
		connectionString = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8&parseTime=True&loc=Local", DBConfig.DB_User, DBConfig.DB_Pass, DBConfig.DB_Host, DBConfig.DB_Port, DBConfig.DB_Name)
		DB, err = gorm.Open(mysql.Open(connectionString), &gorm.Config{})
	}
	if err != nil {
		panic(err)
	}
	sqlDB, err := DB.DB()
	sqlDB.SetMaxOpenConns(100)
	sqlDB.SetMaxIdleConns(100)
	sqlDB.SetConnMaxLifetime(5 * time.Minute)
	return DB, nil //nolint:wsl
}

func GetUserByEmail(email string) (*User, error) {
	var user User
	if err := DB.Where(&User{Email: email}).First(&user).Error; err != nil {
		return nil, err
	}
	return &user, nil //nolint:wsl
}
```


Getting following error when trying to do a load test:

```go
failed to connect to `host=localhost user=postgres database=casbin`: server error (FATAL: sorry, too many clients already (SQLSTATE 53300))
```

What am I missing in above code?