### PR TITLE
customized data type

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: NewCrypto([]byte("jinzhu"))}
 
 	DB.Create(&user)
 
@@ -17,4 +17,5 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	t.Log(result.Name)
 }

--- a/models.go
+++ b/models.go
@@ -1,11 +1,94 @@
 package main
 
 import (
+	"crypto/md5"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/pkg/errors"
+	"gorm.io/gorm/schema"
 	"time"
 
 	"gorm.io/gorm"
 )
+
+type CryptoFieldJsonStorage struct {
+	Plaintext *string `json:"plaintext"`
+	FullHash  *string `json:"full_hash"`
+}
+
+type Crypto struct {
+	data        []byte
+	jsonStorage *CryptoFieldJsonStorage
+}
+
+func (c *Crypto) GormDataType() string {
+	return "json"
+}
+
+// GormDBDataType gorm db data type
+func (c *Crypto) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "sqlite":
+		return "JSON"
+	case "mysql":
+		return "JSON"
+	case "postgres":
+		return "JSONB"
+	}
+	return ""
+}
+
+// Implements driver.Scanner
+func (c *Crypto) Scan(src interface{}) error {
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.New("invalid data type")
+	}
+
+	c.jsonStorage = &CryptoFieldJsonStorage{}
+	err := json.Unmarshal(source, c.jsonStorage)
+	if err != nil {
+		return err
+	}
+
+	//if c.jsonStorage.Plaintext != nil {
+	//	c.data, err = base64.StdEncoding.DecodeString(*c.jsonStorage.Plaintext)
+	//	if err != nil {
+	//		return err
+	//	}
+	//}
+	return nil
+}
+
+// Implements driver.Valuer
+func (c Crypto) Value() (driver.Value, error) {
+	if c.data == nil {
+		return nil, nil // THIS
+	}
+	plaintext := base64.StdEncoding.EncodeToString(c.data)
+	c.jsonStorage.Plaintext = &plaintext
+
+	md5Hash := md5.Sum(c.data)
+	fullHash := hex.EncodeToString(md5Hash[:])
+	c.jsonStorage.FullHash = &fullHash
+
+	jsonStorage, err := json.Marshal(c.jsonStorage)
+	if err != nil {
+		return nil, err
+	}
+	return jsonStorage, nil
+}
+
+func NewCrypto(data []byte) Crypto {
+	return Crypto{
+		data:        data,
+		jsonStorage: &CryptoFieldJsonStorage{},
+	}
+}
+
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
@@ -13,7 +96,7 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
+	Name      Crypto
 	Age       uint
 	Birthday  *time.Time
 	Account   Account


### PR DESCRIPTION
## Explain your user case and expected results
It works as my expectation when using `gorm 1.x`: the `jsonStorage` data is being retained

After I migrate to `gorm 2` and use above code to get user record, the `jsonStorage` data in `User.Name` will be set as nil, although it's value has been assigned in `*Crypto.Scan` method

If change `Name` field in `User` struct from `Crypto` to `*Crypto` type, the `jsonStorage` data in `User.Name` will be retained

I'm not sure if it is a bug, or a deliberate design. Am I missing something? I think we should keep these value that have been scan into customized data type