### PR TITLE
Show panic when DB.WithContext(ctx).Transaction is called on a canceled context.

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "user=gorm password=gorm dbname=gorm host=localhost port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.14
 
 require (
 	github.com/jinzhu/now v1.1.1
-	gorm.io/driver/mysql v0.2.9
-	gorm.io/driver/postgres v0.2.5
-	gorm.io/driver/sqlite v1.0.8
-	gorm.io/driver/sqlserver v0.2.4
+	gorm.io/driver/mysql v0.3.1
+	gorm.io/driver/postgres v0.2.6
+	gorm.io/driver/sqlite v1.0.9
+	gorm.io/driver/sqlserver v0.2.6
 	gorm.io/gorm v0.2.20
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +17,23 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	ctx := context.Background()
+	//	ctx, _ = context.WithTimeout(ctx, time.Nanosecond)
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+	cancelFunc()
+
+	err := DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var result User
+		if err := tx.First(&result, user.ID).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+		user.Name = "foobar"
+		user.ID = 0
+		tx.Create([]User{user})
+
+		return errors.New("some error")
+	})
+
+	t.Error(err)
 }


### PR DESCRIPTION
## Explain your user case and expected results
I expect to have the Transaction() block complete without a panic, and without guard code checking the context in front.

I initially thought this happened if the context is canceled during the transaction, but that seems to work okay.

I will fix my code by checking ctx.Err() but was surprised to see a panic in the library.
