### PR TITLE
failure on using github.com/guregu/null/zero

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &MHAllergy{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module gorm.io/playground
 go 1.14
 
 require (
+	github.com/guregu/null v4.0.0+incompatible
 	github.com/jinzhu/now v1.1.1
-	gorm.io/driver/mysql v0.2.9
-	gorm.io/driver/postgres v0.2.5
-	gorm.io/driver/sqlite v1.0.8
-	gorm.io/driver/sqlserver v0.2.4
+	gorm.io/driver/mysql v0.3.1
+	gorm.io/driver/postgres v0.2.7
+	gorm.io/driver/sqlite v1.0.9
+	gorm.io/driver/sqlserver v0.2.7
 	gorm.io/gorm v0.2.20
 )
 

--- a/go.mod.bak
+++ b/go.mod.bak
@@ -1,0 +1,14 @@
+module gorm.io/playground
+
+go 1.14
+
+require (
+	github.com/jinzhu/now v1.1.1
+	gorm.io/driver/mysql v0.2.9
+	gorm.io/driver/postgres v0.2.5
+	gorm.io/driver/sqlite v1.0.8
+	gorm.io/driver/sqlserver v0.2.4
+	gorm.io/gorm v0.2.20
+)
+
+replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/guregu/null/zero"
 	"gorm.io/gorm"
 )
 
@@ -57,4 +58,10 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+// MHAllergy represents a MHAllergy in the system
+type MHAllergy struct {
+	gorm.Model
+	Allergen zero.String `json:"allergen"`
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-dialects=("sqlite" "mysql" "postgres" "sqlserver")
+dialects=("sqlite")
+# dialects=("sqlite" "mysql" "postgres" "sqlserver")
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then


### PR DESCRIPTION
## Explain your user case and expected results

instead of standard int and string types when you use zero .String, etc then gorm v2 fails. gorm v1 works fine with it. This is an important library to handle null values in json

Following is the output from test

> 2020/08/18 16:38:25 /home/ubuntu/go/pkg/mod/gorm.io/driver/sqlite@v1.0.9/migrator.go:39
> [error] failed to guess github.com/guregu/null/zero.String's relations with gorm.io/playground.MHAllergy's field Allergen, guess level: 3
> 
> 2020/08/18 16:38:25 /home/ubuntu/go/pkg/mod/gorm.io/driver/sqlite@v1.0.9/migrator.go:39
> [error] failed to parse value &main.MHAllergy{Model:gorm.Model{ID:0x0, CreatedAt:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}, UpdatedAt:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}, DeletedAt:gorm.DeletedAt{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}, Valid:false}}, Allergen:zero.String{NullString:sql.NullString{String:"", Valid:false}}}, got error failed to guess github.com/guregu/null/zero.String's relations with gorm.io/playground.MHAllergy's field Allergen, guess level: 3
> 
> 2020/08/18 16:38:25 /home/ubuntu/go/pkg/mod/gorm.io/driver/sqlite@v1.0.9/migrator.go:43
> [error] failed to guess github.com/guregu/null/zero.String's relations with gorm.io/playground.MHAllergy's field Allergen, guess level: 3
> 2020/08/18 16:38:25 Failed to drop table, got error failed to guess github.com/guregu/null/zero.String's relations with gorm.io/playground.MHAllergy's field Allergen, guess level: 3
> FAIL    gorm.io/playground      0.060s
> FAIL.