### PR TITLE
"table has more than one primary key" with embedded struct.

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Corp{}, &Toy{}, &Language{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.14
 
 require (
 	github.com/jinzhu/now v1.1.1
-	gorm.io/driver/mysql v0.2.9
-	gorm.io/driver/postgres v0.2.5
-	gorm.io/driver/sqlite v1.0.8
-	gorm.io/driver/sqlserver v0.2.4
+	gorm.io/driver/mysql v0.3.1
+	gorm.io/driver/postgres v0.2.7
+	gorm.io/driver/sqlite v1.0.9
+	gorm.io/driver/sqlserver v0.2.7
 	gorm.io/gorm v0.2.20
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,14 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	corp := Corp{Base:Company{Name: "jinzhu"}}
 
-	DB.Create(&user)
+	DB.Create(&corp)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var result Corp
+	if err := DB.First(&result, corp.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -54,6 +54,11 @@ type Company struct {
 	Name string
 }
 
+type Corp struct {
+        gorm.Model
+        Base Company `gorm:"embedded;embeddedPrefix:company_"`
+}
+
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string


### PR DESCRIPTION
## Explain your user case and expected results

I am embedding a base struct that contains a field called id. This base struct is embedded with a prefix (say base_) in a new struct. The new struct already has a primary key.

I expected the id field in the embedded struct to get renamed to base_id, and the only primary key should be id in the new struct. But the base_id key is also getting the primary key label, and AutoMigrate on the table is failing with "more than one primary key" error.

 