### PR TITLE
Panic when using composite primary keys for struct without "ID" field

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,12 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		Name: "jinzhu",
+		Labels: []Label{
+			{Name: "region", Value: "emea"},
+		},
+	}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Labels    []Label
 }
 
 type Account struct {
@@ -57,4 +58,10 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+type Label struct {
+	UserID *uint  `gorm:"primarykey"`
+	Name   string `gorm:"primarykey"`
+	Value  string
 }


### PR DESCRIPTION
## Explain your user case and expected results
Creating an association which uses a composite primary key where neither column is named "ID" or "id" causes the library to panic when parsing the schema.

This scenario is common when creating 1-to-many associations where the associated rows don't have any identity. In this example we attach "labels" to an user which stores metadata as a key-value pair, and assign the foreign key to be part of the primary key as well.

Expected result is that the rows should be inserted in the associated table, without a panic.