### PR TITLE
supply test for panic after setting a key with db.set()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	//"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,21 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	DB := DB.Set("Test", "1")
+	toy := Toy{
+		Name:      "test",
+		OwnerID:   "john",
+		OwnerType: "humanoid",
 	}
+	DB.Create(&toy)
+	// when we do this instead it works:
+	// DB.Session(&gorm.Session{
+	// 	WithConditions: true,
+	// }).Create(&toy)
+
+	company := Company{
+		ID:   1,
+		Name: "Evil Corp",
+	}
+	DB.Create(&company)
 }


### PR DESCRIPTION
## Explain your user case and expected results
When you do these things in following order:

1. Set key via db.Set()
2. Create a toy
3. Try to create a company

It panics while trying to do number 3. One workaround seems to be, to set the session attribute "WithConditions" to true in step 2. I am unsure though why this is the case.