### PR TITLE
Automigrate postgres goes in error with default tag

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -5,16 +5,17 @@ import (
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
+// GORM_BRANCH: v1.20.0
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	type Product struct {
+		Value float64 `gorm:"default:1"`
+	}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	for i := 0; i < 2; i++ {
+		if err := DB.AutoMigrate(&Product{}); err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

Automigrate (only with Postgres database) goes in error with default tag.
This problem appears when automigrate running after the table and column already exists.
This problem appear in v1.20.0 branch (last tag for my go modules), i think that problem are already fixed in master branch.
If this is the case, please release a new tag.