### PR TITLE
RETURNING excludes computed cols

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,9 @@ func TestGORM(t *testing.T) {
 		LastName string `gorm:"type:varchar;"`
 		FullName string `gorm:"->;type:varchar GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) STORED"`
 	}
+	if err := DB.AutoMigrate(&exampleWithComputedCols{}); err != nil {
+		t.Errorf("Failed test setup: error = %v", err)
+	}
 	
 	original := exampleWithComputedCols{
 		FirstName: "jon",

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,7 @@ func TestGORM(t *testing.T) {
 	
 	original := exampleWithComputedCols{
 		FirstName: "jon",
-		LastName: "hartman"
+		LastName: "hartman",
 	}
 	if err := DB.Create(&original).Error; err != nil {
 		t.Errorf("Failed create: error = %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -30,8 +30,8 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed load: error = %v", err)
 	}
 	// It's expected that this is OK; since we're reloading a fresh struct
-	if results.FullName != "jon hartman" {
-		t.Errorf("Reloaded struct: computed 'Full Name' mismatch: have %s", results.FullName)
+	if result.FullName != "jon hartman" {
+		t.Errorf("Reloaded struct: computed 'Full Name' mismatch: have %s", result.FullName)
 	}
 	// However, this will fail - since the .Create() call above will not add full_name to the RETURNING clause (at least
 	// with POSTGRES syntax). We get "RETURNING id, created_at, updated_at", while to make it return the computed column

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,33 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	type exampleWithComputedCols struct {
+		gorm.Model
+		FirstName string `gorm:"type:varchar;"`
+		LastName string `gorm:"type:varchar;"`
+		FullName string `gorm:"->;type:varchar GENERATED ALWAYS AS (CONCAT(first_name, ' ', last_name)) STORED"`
+	}
+	
+	original := exampleWithComputedCols{
+		FirstName: "jon",
+		LastName: "hartman"
+	}
+	if err := DB.Create(&original).Error; err != nil {
+		t.Errorf("Failed create: error = %v", err)
+	}
+	
+	var result exampleWithComputedCols
+	if err := DB.First(&result, original.ID).Error; err != nil {
+		t.Errorf("Failed load: error = %v", err)
+	}
+	// It's expected that this is OK; since we're reloading a fresh struct
+	if results.FullName != "jon hartman" {
+		t.Errorf("Reloaded struct: computed 'Full Name' mismatch: have %s", results.FullName)
+	}
+	// However, this will fail - since the .Create() call above will not add full_name to the RETURNING clause (at least
+	// with POSTGRES syntax). We get "RETURNING id, created_at, updated_at", while to make it return the computed column
+	// value from 'first_name', it would need "RETURNING id, created_at, updated_at, full_name"
+	if original.FullName != "jon hartman" {
+		t.Errorf("Original struct on write: computed 'Full Name' mismatch: have %s", original.FullName)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
Support returning "generated/computed" column values on create/update.

With POSTGRES supporting computed/generated columns, it'd be great to have those columns come back in the RETURNING clause, instead of needing to reload the values after a mutation. In `schema/schema.go` around line 182, it looks like `FieldsWithDefaultDBValue` property on the schema is what's used to determine what should be generated in the RETURNING clause. If the schema also kept track of computed columns, it looks like a (fairly) easy addition to add the computed columns that should be returned.