### PR TITLE
Using Preload(clause.Associations) fails to preload "grandchild" has-many relations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	gorm.io/gorm v1.20.1
 )
 
-replace gorm.io/gorm => ./gorm
+

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm/clause"
 	"testing"
 )
 
@@ -8,13 +9,58 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Asset struct {
+	ID         int
+	Kind       string
+	Value      float32
+	BusinessID int
+}
+
+type Business struct {
+	ID       int
+	Name     string
+	Assets   []Asset `gorm:"foreignkey:BusinessID;"`
+	PersonID int
+}
+
+type Person struct {
+	ID       int
+	Name     string
+	Business Business   `gorm:"foreignkey:PersonID;"`
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	err := DB.AutoMigrate(&Person{}, &Business{}, &Asset{})
+	if err != nil {
+		panic(err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err = DB.Create(&Person{
+		Name: "Jinzhu",
+		Business: Business{
+			Name: "GORM",
+			Assets: []Asset{
+				{
+					Kind: "Cash",
+					Value: 10000,
+				},
+			},
+		},
+	}).Error; err != nil {
+		panic(err)
+	}
+
+	people := make([]Person, 0)
+
+	// If I do the following, it works:
+	// db.Preload("Company").Preload("Company.Address").Preload("Company.Assets")
+	// But not if I do this:
+	err = DB.Preload(clause.Associations).Find(&people).Error
+	if err != nil {
+		panic(err)
+	}
+	if people[0].Business.Assets == nil {
+		panic("despite having assets, they are not preloaded, and are nil")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"gorm.io/gorm/clause"
+	"errors"
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -15,14 +16,12 @@ type Asset struct {
 	Value      float32
 	BusinessID int
 }
-
 type Business struct {
 	ID       int
 	Name     string
 	Assets   []Asset `gorm:"foreignkey:BusinessID;"`
 	PersonID int
 }
-
 type Person struct {
 	ID       int
 	Name     string
@@ -35,32 +34,11 @@ func TestGORM(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	p := &Person{}
+	result := DB.Find(p, "id = ?", "nothing")
 
-	if err = DB.Create(&Person{
-		Name: "Jinzhu",
-		Business: Business{
-			Name: "GORM",
-			Assets: []Asset{
-				{
-					Kind: "Cash",
-					Value: 10000,
-				},
-			},
-		},
-	}).Error; err != nil {
-		panic(err)
+	if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		t.Fail()
 	}
 
-	people := make([]Person, 0)
-
-	// If I do the following, it works:
-	// db.Preload("Company").Preload("Company.Address").Preload("Company.Assets")
-	// But not if I do this:
-	err = DB.Preload(clause.Associations).Find(&people).Error
-	if err != nil {
-		panic(err)
-	}
-	if people[0].Business.Assets == nil {
-		panic("despite having assets, they are not preloaded, and are nil")
-	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
When you have a has-many relation within a sub-relation of the main resource, using Preload(clause.Associations) does not preload it.

In this case, `Person` has one `Business` that has many `Asset`. When I do a `DB.Preload(clause.Associations.Find()`, `Business` gets properly preloaded, but `Asset` does not, and remains nil.

Note: I tried this with a sub has-one relation (instead of has-many) and it works fine.