### PR TITLE
Migrator not working with transactions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,21 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type TestData struct {
+	Id   int
+	Data string
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	tx := DB.Begin()
+	tx.Migrator().AutoMigrate(&TestData{})
+	if err = tx.Rollback().Error; err != nil {
+		t.Error(err)
 	}
+
+	test := TestData{Data: "blub"}
+	if err = DB.Save(&test).Error; err == nil {
+		t.Log("table shouldn't exist")
+		t.FailNow()
+	}	
 }

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,7 @@ type TestData struct {
 func TestGORM(t *testing.T) {
 	tx := DB.Begin()
 	tx.Migrator().AutoMigrate(&TestData{})
+	var err error
 	if err = tx.Rollback().Error; err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
### Explain your user case and expected results
Given an old database and a new schema when an error occures then gorm should be capable of doing a rollback to the original state. Therefore it is necessary that the Migrator can run within an transaction. This is not the case.