### PR TITLE
Update single column (or map update) doesn't work

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -13,8 +14,7 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Where(User{Model: gorm.Model{ID: user.ID}}).Update("name", "foo").Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
Updating a single column by `Update` and `UpdateColumn` simply doesn't work. It returns an error: `unsupported data type: map[<col_name>:<col_value>]`. It also happens with `Updates(map[string]interface{}{...})`
This is not matching the function documentation and the official documentation (https://gorm.io/docs/update.html).