### PR TITLE
Incorrect statement table when using preloaded

### DIFF
--- a/db.go
+++ b/db.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -77,6 +78,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	} else if debug == "false" {
 		db.Logger = db.Logger.LogMode(logger.Silent)
 	}
+
+	// Force the database to preload relationships
+	db = db.Set("gorm:auto_preload", true)
 
 	return
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	gorm.io/driver/mysql v1.0.1
-	gorm.io/driver/postgres v1.0.0
+	gorm.io/driver/postgres v1.0.1
 	gorm.io/driver/sqlite v1.1.3
 	gorm.io/driver/sqlserver v1.0.4
 	gorm.io/gorm v1.20.1

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,23 @@ func TestGORM(t *testing.T) {
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+		t.Fatalf("Failed, got error: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("The code did not panic")
+			return
+		}
+
+		t.Logf("Test paniced as expected: %v", r)
+	}()
+
+	// Statement is still set for some reason
+	t.Logf("Statement Table: %s", DB.Statement.Table)
+
+	if err := DB.Save(&Language{Code: "Code"}).Error; err == nil {
+		t.Fatal("We expected this to fail")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When using `auto_preload: true` the `DB.Statement` is not cleared causing issues with the queries afterwards. Since `DB.Statement.Table` is `users` instead of `languages` (or just empty, which is what happens if you don't `auto_preload`).

I highly expect that this is unwanted behaviour since this doesn't happen in in V1 or with `auto_preload: false`.