### PR TITLE
Namer ColumnName - wrong table name when using embedded base model

### DIFF
--- a/db.go
+++ b/db.go
@@ -49,13 +49,13 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 		}
-		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{NamingStrategy: NamingStrategy{}})
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{NamingStrategy: NamingStrategy{}})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;
@@ -66,10 +66,10 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "sqlserver://gorm:LoremIpsum86@localhost:9930?database=gorm"
 		}
-		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{NamingStrategy: NamingStrategy{}})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{NamingStrategy: NamingStrategy{}})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {

--- a/naming.go
+++ b/naming.go
@@ -17,6 +17,10 @@ func (ns NamingStrategy) TableName(table string) string {
 func (ns NamingStrategy) ColumnName(table, column string) string {
 	baseColumnName := ns.baseStrategy.ColumnName(table, column)
 
+	if table == "" {
+		return baseColumnName
+	}
+
 	s := strings.Split(table, "_")
 
 	var prefix string

--- a/naming.go
+++ b/naming.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+
+	"gorm.io/gorm/schema"
+)
+
+type NamingStrategy struct {
+	baseStrategy schema.NamingStrategy
+}
+
+func (ns NamingStrategy) TableName(table string) string {
+	return ns.baseStrategy.TableName(table)
+}
+
+func (ns NamingStrategy) ColumnName(table, column string) string {
+	baseColumnName := ns.baseStrategy.ColumnName(table, column)
+
+	s := strings.Split(table, "_")
+
+	var prefix string
+	switch len(s) {
+	case 1:
+		prefix = s[0][:3]
+	case 2:
+		prefix = s[0][:1] + s[1][:2]
+	default:
+		prefix = s[0][:1] + s[1][:1] + s[2][:1]
+	}
+	return prefix + "_" + baseColumnName
+}
+
+func (ns NamingStrategy) JoinTableName(table string) string {
+	return ns.baseStrategy.JoinTableName(table)
+}
+
+func (ns NamingStrategy) RelationshipFKName(rel schema.Relationship) string {
+	return ns.baseStrategy.RelationshipFKName(rel)
+}
+
+func (ns NamingStrategy) CheckerName(table, column string) string {
+	return ns.baseStrategy.CheckerName(table, column)
+}
+
+func (ns NamingStrategy) IndexName(table, column string) string {
+	return ns.baseStrategy.IndexName(table, column)
+}


### PR DESCRIPTION
### Wrong table name on ColumnName
The table name is generated by reflection and saved to the field.
This behavior is implemented here: https://github.com/go-gorm/gorm/blob/f6ed895caffcde0b37d181201a5cadd442b8879e/schema/schema.go#L96

While parsing the field from the base model, `Parse` is called again, but this time `dest` is of the type of the base model:
https://github.com/go-gorm/gorm/blob/68920449f92f24c8b17d90986eb155c251ed8fc7/schema/field.go#L329

If the `ColumnName` function is overridden and uses the table name, the behavior might be unexpected.
In this test, the function was overridden to add a prefix based on the table name.

For example, after running the migration in this test, the users table will be like:

![test_result](https://user-images.githubusercontent.com/5438762/93946234-1d87d780-fd0f-11ea-89cd-31c2855c1c4e.png)
