### PR TITLE
Cannot insert or update JSON Array data to datatypes.JSON column

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &UserWithJSON{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module gorm.io/playground
 go 1.14
 
 require (
-	gorm.io/driver/mysql v1.0.1
-	gorm.io/driver/postgres v1.0.0
-	gorm.io/driver/sqlite v1.1.3
-	gorm.io/driver/sqlserver v1.0.4
+	gorm.io/datatypes v0.0.0-20200806042100-bc394008dd0d
+	gorm.io/driver/mysql v0.3.1
+	gorm.io/driver/postgres v0.2.6
+	gorm.io/driver/sqlite v1.0.8
+	gorm.io/driver/sqlserver v0.2.5
 	gorm.io/gorm v1.20.1
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -9,11 +11,16 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	jsonData := `{"name": "json-1", "attributes": ["tag1", "tag2"]}`
+	var jsonMap map[string]interface{}
+	if err := json.NewDecoder(strings.NewReader(jsonData)).Decode(&jsonMap); err != nil {
+		t.Fatal(err)
+	}
 
-	DB.Create(&user)
+	user := &UserWithJSON{}
+	DB.Where(&UserWithJSON{Name: "json-1"}).Assign(jsonMap).FirstOrCreate(user)
 
-	var result User
+	var result UserWithJSON
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}

--- a/models.go
+++ b/models.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"gorm.io/datatypes"
+
 	"gorm.io/gorm"
 )
 
@@ -57,4 +59,12 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+
+// UserWithJSON is a table with JSON column
+type UserWithJSON struct {
+	gorm.Model
+	Name       string         `json:"name" gorm:"type:varchar(128)"`
+	Attributes datatypes.JSON `json:"attributes" gorm:"type:json"`
 }


### PR DESCRIPTION
## User Case
Cannot write JSON Array data to `datatypes.JSON` column

First defined a table with a `datatypes.JSON` column, which stores json array data.

```
type UserWithJSON struct {
	gorm.Model
	Name       string         `json:"name" gorm:"type:varchar(128)"`
	Attributes datatypes.JSON `json:"attributes" gorm:"type:json"`
}
```

Then do the **create or update** operation on this table:

```
jsonData := `{"name": "json-1", "attributes": ["tag1", "tag2"]}`
var jsonMap map[string]interface{}
if err := json.NewDecoder(strings.NewReader(jsonData)).Decode(&jsonMap); err != nil {
	t.Fatal(err)
}
user := &UserWithJSON{}
DB.Where(&UserWithJSON{Name: "json-1"}).Assign(jsonMap).FirstOrCreate(user)


// The below code didn't work either
DB.Where(&UserWithJSON{Name: "json-1"}).
	Assign(map[string]interface{}{"name": "json-1", "attributes": []string{"tag1", "tag2"}}).
	FirstOrCreate(user)


// The below code didn't work either
user := &UserWithJSON{}
DB.Where(&UserWithJSON{Name: "json-1"}).
	Assign(map[string]interface{}{"name": "json-1", "attributes": datatypes.JSON(`["tag3", "tag4"]`)}).
	FirstOrCreate(user)
```

`Insert` result:

```
/playground/main_test.go:27 record not found
[0.061ms] [rows:0] SELECT * FROM `user_with_jsons` WHERE `user_with_jsons`.`name` = "json-1" AND `user_with_jsons`.`deleted_at` IS NULL ORDER BY `user_with_jsons`.`id` LIMIT 1

/playground/main_test.go:27
[0.833ms] [rows:1] INSERT INTO `user_with_jsons` (`created_at`,`updated_at`,`deleted_at`,`name`,`attributes`) VALUES ("2020-09-23 21:15:35.702","2020-09-23 21:15:35.702",NULL,"json-1",NULL)

/playground/main_test.go:30
[0.181ms] [rows:1] SELECT * FROM `user_with_jsons` WHERE `user_with_jsons`.`id` = 4 AND `user_with_jsons`.`deleted_at` IS NULL ORDER BY `user_with_jsons`.`id` LIMIT 1
    main_test.go:34: {"ID":4,"CreatedAt":"2020-09-23T21:15:35.702906+08:00","UpdatedAt":"2020-09-23T21:15:35.702906+08:00","DeletedAt":{"Time":"0001-01-01T00:00:00Z","Valid":false},"name":"json-1","attributes":null}
--- PASS: TestGORM (0.00s)
PASS
```

`Update` result:

```
/playground/main_test.go:27
[0.133ms] [rows:1] SELECT * FROM `user_with_jsons` WHERE `user_with_jsons`.`name` = "json-1" AND `user_with_jsons`.`deleted_at` IS NULL ORDER BY `user_with_jsons`.`id` LIMIT 1

/playground/main_test.go:27
[1.020ms] [rows:1] UPDATE `user_with_jsons` SET `name`="json-1",`updated_at`="2020-09-23 21:17:06.951" WHERE `user_with_jsons`.`name` = "json-1" AND `user_with_jsons`.`deleted_at` IS NULL AND `id` = 4

/playground/main_test.go:30
[0.109ms] [rows:1] SELECT * FROM `user_with_jsons` WHERE `user_with_jsons`.`id` = 4 AND `user_with_jsons`.`deleted_at` IS NULL ORDER BY `user_with_jsons`.`id` LIMIT 1
    main_test.go:34: {"ID":4,"CreatedAt":"2020-09-23T21:15:35.702906+08:00","UpdatedAt":"2020-09-23T21:17:06.951234+08:00","DeletedAt":{"Time":"0001-01-01T00:00:00Z","Valid":false},"name":"json-1","attributes":null}
--- PASS: TestGORM (0.00s)
PAS
```
 
Both of the `Insert` and `Update` operation didn't parse the `datatype.JSON` column correctly.

**Create** directly didn't work either

```
jsonData := `{"name": "json-1", "attributes": ["tag1", "tag2"]}`
var jsonMap map[string]interface{}
if err := json.NewDecoder(strings.NewReader(jsonData)).Decode(&jsonMap); err != nil {
    t.Fatal(err)
}

DB.Model(&UserWithJSON{}).Create(jsonMap)
```

Still cannot write json array data to `datatypes.JSON` column

```
/playground/main_test.go:33 row value misused
[0.074ms] [rows:0] INSERT INTO `user_with_jsons` (`attributes`,`name`) VALUES (("tag1","tag2"),"json-1")
```


**Update** directly didn't work either

```
DB.Where(&UserWithJSON{Name: "json-1"}).Updates(jsonMap)
```

Got below error:

```
unsupported data type: map[attributes:[tag1 tag2] name:json-1]
[253432.236ms] [rows:0] 
```

## Expected Result
The below 3 methods can create or update the JSON Array data to `datatypes.JSON` column correctly:

- `DB.Where().Assign().FirstOrCreate()`
- `DB.Model().Create()`
- `DB.Where().Updates()`