### PR TITLE
[sqlserver] Create method does not return error on duplicate rows. 

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,33 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlserver
+
+type Parent struct {
+	gorm.Model
+	Name string `gorm:"uniqueIndex;size:200"`
+}
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	const parentName = "John"
+	user1 := Parent{Name: parentName}
+	user2 := Parent{Name: parentName}
 
-	DB.Create(&user)
+	_ = DB.AutoMigrate(&Parent{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err := DB.Create(&user1).Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	err = DB.Create(&user2).Error
+	if err == nil {
+		t.Errorf("Failed, must raise duplicate key error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When using `sqlserver` dialect `Create` method silently fails on duplicate insert. Expected result would be for `Create` method to return relevant error.