### PR TITLE
Find().Pluck() cause panic

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,26 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	samples := []*Sample{
+		{
+			SampleId:      "s-1",
+			OtherSampleId: "ss-1",
+		},
+		{
+			SampleId:      "s-2",
+			OtherSampleId: "ss-2",
+		},
+		{
+			SampleId:      "s-3",
+			OtherSampleId: "ss-3",
+		},
+	}
+	DB.AutoMigrate(&Sample{})
+	DB.Create(&samples)
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	result := []*Sample{}
+	var ids []string
+	if err := DB.Find(&result).Pluck("other_sample_id", &ids).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,8 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Sample struct {
+	SampleId      string
+	OtherSampleId string
+}


### PR DESCRIPTION
## Explain your user case and expected results

Panic occurs when the Find() and the Pluck() are used together.
The type below consists of the same structure as the type I use.