### PR TITLE
Some drivers ColumnType has missing information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 gorm
+mysql
+postgres
 go.sum
 .*
 *.db

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module gorm.io/playground
 go 1.14
 
 require (
-	gorm.io/driver/mysql v1.0.1
-	gorm.io/driver/postgres v1.0.2
+	gorm.io/driver/mysql v1.0.2
+	gorm.io/driver/postgres v1.0.4
 	gorm.io/driver/sqlite v1.1.3
-	gorm.io/driver/sqlserver v1.0.4
+	gorm.io/driver/sqlserver v1.0.5
 	gorm.io/gorm v1.20.2
 )
 
 replace gorm.io/gorm => ./gorm
+replace gorm.io/driver/mysql => ./mysql
+replace gorm.io/driver/postgres => ./postgres

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
+// MYSQL_REPO: https://github.com/asmeikal/mysql.git
+// POSTGRES_REPO: https://github.com/asmeikal/postgres.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: mysql, postgres, sqlserver
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,38 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+func TestColumnTypeLengthInfo(t *testing.T) {
+	columns, err := DB.Migrator().ColumnTypes(&User{})
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	for _, c := range columns {
+		if c.Name() == "string_len" {
+			if _, ok := c.Length(); !ok {
+				t.Errorf("%s: missing length information on column %s", os.Getenv("GORM_DIALECT"), c.Name())
+			}
+		}
+	}
+}
+
+func TestColumnTypeNullableInfo(t *testing.T) {
+	columns, err := DB.Migrator().ColumnTypes(&User{})
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	for _, c := range columns {
+		if _, ok := c.Nullable(); !ok {
+			t.Errorf("%s: missing nullable information on column %s", os.Getenv("GORM_DIALECT"), c.Name())
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"gorm.io/gorm"
 	"os"
 	"testing"
 )
@@ -11,30 +13,75 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: mysql, postgres, sqlserver
 
-func TestColumnTypeLengthInfo(t *testing.T) {
+func getColumn(value interface{}, name string) (gorm.ColumnType, error) {
 	columns, err := DB.Migrator().ColumnTypes(&User{})
 	if err != nil {
-		t.Errorf("Failed, got error: %v", err)
+		return nil, fmt.Errorf("failed to get columns for entity %v: %w", value, err)
 	}
 
 	for _, c := range columns {
-		if c.Name() == "string_len" {
-			if _, ok := c.Length(); !ok {
-				t.Errorf("%s: missing length information on column %s", os.Getenv("GORM_DIALECT"), c.Name())
-			}
+		if c.Name() == name {
+			return c, nil
 		}
+	}
+
+	return nil, fmt.Errorf("column %s not found", name)
+}
+
+func TestHasTable(t *testing.T) {
+	out := DB.Migrator().HasTable(&User{})
+
+	if !out {
+		t.Errorf("table for %#v not found", &User{})
+	}
+}
+
+func TestHasColumn(t *testing.T) {
+	out := DB.Migrator().HasColumn(&User{}, "name")
+
+	if !out {
+		t.Errorf("column name not found")
+	}
+}
+
+func TestColumnTypeLengthInfo(t *testing.T) {
+	columnsWithLength := []string{
+		"string_len",
+	}
+
+	for _, columnName := range columnsWithLength {
+		t.Run(fmt.Sprintf("column %s has length", columnName), func(t *testing.T) {
+			column, err := getColumn(&User{}, columnName)
+
+			if err != nil {
+				t.Errorf("Failed, got error: %v", err)
+			}
+
+			if _, ok := column.Length(); !ok {
+				t.Errorf("%s: missing length information on column %s", os.Getenv("GORM_DIALECT"), column.Name())
+			}
+		})
 	}
 }
 
 func TestColumnTypeNullableInfo(t *testing.T) {
-	columns, err := DB.Migrator().ColumnTypes(&User{})
-	if err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	columnsWithNullable := []string{
+		"name",
+		"age",
+		"string_len",
 	}
 
-	for _, c := range columns {
-		if _, ok := c.Nullable(); !ok {
-			t.Errorf("%s: missing nullable information on column %s", os.Getenv("GORM_DIALECT"), c.Name())
-		}
+	for _, columnName := range columnsWithNullable {
+		t.Run(fmt.Sprintf("column %s has nullable", columnName), func(t *testing.T) {
+			column, err := getColumn(&User{}, columnName)
+
+			if err != nil {
+				t.Errorf("Failed, got error: %v", err)
+			}
+
+			if _, ok := column.Nullable(); !ok {
+				t.Errorf("%s: missing nullable information on column %s", os.Getenv("GORM_DIALECT"), column.Name())
+			}
+		})
 	}
 }

--- a/models.go
+++ b/models.go
@@ -13,8 +13,9 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
+	Name      string `gorm:"not null"`
+	Age       uint   `gorm:"nullable"`
+	StringLen string `gorm:"size:255"`
 	Birthday  *time.Time
 	Account   Account
 	Pets      []*Pet

--- a/test.sh
+++ b/test.sh
@@ -8,9 +8,11 @@ rm -rf gorm
 fi
 
 [ -d gorm ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}'))
+[ -d mysql ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep MYSQL_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep MYSQL_REPO | awk '{print $3}'))
+[ -d postgres ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep POSTGRES_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep POSTGRES_REPO | awk '{print $3}'))
 
 cp go.mod go.mod.bak
-sed '/gorm.io\/driver/d' go.mod.bak > go.mod
+#sed '/gorm.io\/driver/d' go.mod.bak > go.mod
 
 for dialect in "${dialects[@]}" ; do
   if [ "$GORM_DIALECT" = "" ] || [ "$GORM_DIALECT" = "${dialect}" ]


### PR DESCRIPTION
`sql.ColumnType` does not guarantee that all optional information (`Nullable`, `Length`, `DecimalSize`) is available with all drivers. `postgres` is missing `Nullable` info for all fields (even if explicitly marked as `not null` or `nullable`), while `mysql` is missing `Length` information (even if specified with `size`).