### PR TITLE
demonstrate schema name being dropped

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,21 +9,20 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 type OtherSchemaTable struct {
-    AColumn string	
+	AColumn string `gorm:"primary_key"`
 }
 
 func (OtherSchemaTable) TableName() string {
-    return "otherschema.other_schema_table"	
+	return "otherschema.other_schema_table"
 }
-
 
 func TestGORM(t *testing.T) {
 	if err := DB.AutoMigrate(&OtherSchemaTable{}); err != nil {
-		t.Errorf("Failed to automigrate: %s", err)	
+		t.Errorf("Failed to automigrate: %s", err)
 	}
-	
+
 	result := make([]OtherSchemaTable, 0)
-	
+
 	if err := DB.Find(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,23 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type OtherSchemaTable struct {
+    AColumn string	
+}
+
+func (OtherSchemaTable) TableName() string {
+    return "otherschema.other_schema_table"	
+}
+
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.AutoMigrate(&OtherSchemaTable{}); err != nil {
+		t.Errorf("Failed to automigrate: %s", err)	
+	}
+	
+	result := make([]OtherSchemaTable, 0)
+	
+	if err := DB.Find(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

AutoMigrate doesn't honor the schema name provided in the TableName but other queries (insert, select, update) do. This results in AutoMigrate creating the table in the wrong schema and subsequent operations failing.

I expect AutoMigrate to preserve the schema name provided in TableName.

My specific case is on postgres.