### PR TITLE
Race when using a DB instance from multiple goroutines

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "user=gorm password=gorm dbname=gorm host=localhost port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module gorm.io/playground
 go 1.14
 
 require (
-	gorm.io/driver/mysql v1.0.1
-	gorm.io/driver/postgres v1.0.2
+	gorm.io/driver/mysql v1.0.2
+	gorm.io/driver/postgres v1.0.4
 	gorm.io/driver/sqlite v1.1.3
-	gorm.io/driver/sqlserver v1.0.4
+	gorm.io/driver/sqlserver v1.0.5
 	gorm.io/gorm v1.20.2
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"math/rand"
+	"sync"
 	"testing"
+	"time"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +14,52 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	stop := make(chan struct{})
+	wg := sync.WaitGroup{}
 
-	DB.Create(&user)
+	n := 10
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go dbconsumer(t, DB, stop, &wg)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	time.Sleep(2 * time.Second)
+
+	close(stop)
+	wg.Wait()
+}
+
+func dbconsumer(t *testing.T, db *gorm.DB, stop <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var result struct {
+		N int64
+	}
+	var err error
+	query := "select 42 as n"
+
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+			r := rand.Intn(100)
+			time.Sleep(time.Duration(r) * time.Microsecond)
+
+			// If we do this, there is no race.
+			// db = db.WithContext(context.Background())
+
+			err = db.Raw(query).Scan(&result).Error
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if result.N != 42 {
+				t.Errorf("expected result to be 42, got: %d", result.N)
+				return
+			}
+
+			result.N = 0
+		}
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

I might have misunderstood the documentation, but it seems to me that this should be the same as the first example from the documentation, demonstrating what should be a safe way of using a DB instance from multiple goroutines.

https://gorm.io/docs/method_chaining.html#Method-Chain-Safety-Goroutine-Safety

```go
db, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})

// Safe for new initialized *gorm.DB
for i := 0; i < 100; i++ {
  go db.Where(...).First(&user)
}
```

Also, when I followed the instructions, before making any changes to `main_test.go`, the tests didn't work for me with PostgreSQL started with Docker Compose.

I got the following error:
```
[error] failed to initialize database, got error failed to connect to `host=/tmp user=gorm database=gorm`: dial error (dial unix /tmp/.s.PGSQL.9920: connect: no such file or directory)
2020/10/22 09:46:03 failed to connect database, got error failed to connect to `host=/tmp user=gorm database=gorm`: dial error (dial unix /tmp/.s.PGSQL.9920: connect: no such file or directory)
```

I made a small fix for that first.
