### PR TITLE
Added one to many use case

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -32,5 +32,7 @@ func TestGORM(t *testing.T) {
 
 	_db.AutoMigrate(&TestFile{},&TestFileList{})
 
-	_db.Clauses(clause.OnConflict{DoNothing: true}).Create(zart)
+	if err := _db.Clauses(clause.OnConflict{DoNothing: true}).Create(zart).Error ; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"testing"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/driver/sqlite"
@@ -16,7 +17,11 @@ type TestFileList struct {
 	Files []TestFile `gorm:"ForeignKey:ProjName"`
 }
 
-func main() {
+// GORM_REPO: https://github.com/go-gorm/gorm.git
+// GORM_BRANCH: master
+// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+
+func TestGORM(t *testing.T) {
 	var files []TestFile
 
 	files = append(files,TestFile{"test","test"})

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,31 @@
 package main
 
 import (
-	"testing"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/driver/sqlite"
 )
 
-// GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+type TestFile struct {
+	ProjName string
+	File string
+}
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+type TestFileList struct {
+	ProjName string `gorm:"primaryKey"`
+	Files []TestFile `gorm:"ForeignKey:ProjName"`
+}
 
-	DB.Create(&user)
+func main() {
+	var files []TestFile
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	files = append(files,TestFile{"test","test"})
+
+	zart := TestFileList {"test",files}
+
+	_db,_ := gorm.Open(sqlite.Open("db.sql"), &gorm.Config{PrepareStmt: true})
+
+	_db.AutoMigrate(&TestFile{},&TestFileList{})
+
+	_db.Clauses(clause.OnConflict{DoNothing: true}).Create(zart)
 }


### PR DESCRIPTION
My intention is to insert a struct (TestFileList), that has a one to many relation with TestFile (i.e One TestFileList points to one or more TestFile).

Although i have read the association documentation, and have tried various things i have not managed to make it work.

Localy i am getting the following errors

```
2020/10/29 22:23:49 /tmp/test.go:30 near "UPDATE": syntax error
[0.032ms] [rows:0] INSERT INTO `test_files` (`proj_name`,`file`) VALUES ("test","test") ON CONFLICT DO UPDATE SET `proj_name`=`excluded`.`proj_name`

2020/10/29 22:23:49 /tmp/test.go:30 near "UPDATE": syntax error
[0.662ms] [rows:1] INSERT INTO `test_file_lists` (`proj_name`) VALUES ("test") ON CONFLICT DO NOTHING
```

The same behavior occurs in the playground.
I really don't understand what i am doing wrong ... 