### PR TITLE
Reproduces a Table api bug

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -10,10 +10,17 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
+	pet := Pet{Name: "snow"}
 	DB.Create(&user)
-
+	DB.Create(&pet)
+	
 	var result User
+	subQuery1 := DB.Model(&User{}).Select("name")
+	subQuery2 := DB.Model(&Pet{}).Select("name")
+
+	db.Table("(?) as u, (?) as p", subQuery1, subQuery2).Find(&User{})
+
+	// SELECT * FROM (SELECT `name` FROM `users`) as u, (SELECT `name` FROM `pets`) as p
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}


### PR DESCRIPTION
## Explain your user case and expected results

I'm doing a "from subquery" following by this [docs](https://gorm.io/docs/advanced_query.html#From-SubQuery)
but when I pass subquery arguments into table api, it result an error **"too many arguments"**.

<img width="987" alt="Screen Shot 2563-11-02 at 03 50 51" src="https://user-images.githubusercontent.com/32630922/97815136-a145c400-1cbe-11eb-80d3-197ab34b014d.png">
