### PR TITLE
Prevent returning of embedded struct primary key on insert (create)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -4,17 +4,26 @@ import (
 	"testing"
 )
 
+type User struct {
+	ID         int `gorm:"primaryKey"`
+	Name       string
+	CompanyID  int
+
+	Company    *Company `gorm:"embedded;embeddedPrefix:com"`
+}
+
+type Company struct {
+	ID        int `gorm:"primaryKey"`
+	Name      string
+}
+
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	user := User{Name: "jinzhu", CompanyID: 1}
+	if err := DB.Create(&user).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
Insert a struct without its embedded struct.
If a prefixed embedded struct has primary key, it will be returned on insert by "RETURNING ..." and causes an error like: "column "...id" does not exist"