### PR TITLE
Soft delete with Where and without PK updating soft deleted records

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,62 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "test user"}
 
-	DB.Create(&user)
+	r := DB.Create(&user)
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	pet := Pet{
+		UserID: &user.ID,
+		Name:   "Pet 1",
+	}
+
+	r = DB.Create(&pet)
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
+
+	pet = Pet{
+		UserID: &user.ID,
+		Name:   "Pet 2",
+	}
+
+	r = DB.Create(&pet)
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
+
+	r = DB.Where(Pet{
+		UserID: &user.ID,
+	}).Delete(Pet{})
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
+
+	if r.RowsAffected != 2 {
+		t.Errorf("unexpected number of affected rows. expected: 2; got: %v", r.RowsAffected)
+	}
+
+	pet = Pet{
+		UserID: &user.ID,
+		Name:   "Pet 3",
+	}
+
+	r = DB.Create(&pet)
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
+
+	r = DB.Where(Pet{
+		UserID: &user.ID,
+	}).Delete(Pet{})
+	if r.Error != nil {
+		t.Errorf("error: %v", r.Error)
+	}
+
+	if r.RowsAffected != 1 {
+		t.Errorf("unexpected number of affected rows. expected: 1; got: %v", r.RowsAffected)
 	}
 }


### PR DESCRIPTION
If we want to delete, for example, every `Pet` from a `User`, we'd do something like this:

```go
DB.Where(Pet{UserID: &user.ID}).Delete(Pet{})
```

The resulting SQL would be something like this:

```sql
UPDATE `pets` SET `deleted_at`="2020-11-04 11:28:09.499" WHERE `pets`.`user_id` = 1
```

Note that ALL pets with `user_id = 1` will have its `deleted_at` field updated, including already soft deleted records.
My suggestion is to add the `DeletedAt` in the `WHERE` clause, resulting in something like this:

```sql
UPDATE `pets` SET `deleted_at`="2020-11-04 11:28:09.499" WHERE `pets`.`user_id` = 1 AND `deleted_at` IS NULL
```

In my opinion, even if the primary key is informed, if the record is already soft deleted, the `deleted_at` field must not be updated.