### PR TITLE
Pluck working differently in v2

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,16 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	var names []string
+	DB.Raw(`select name from users`).Pluck("name", &names)
+
+	if len(names) != 1 {
+		t.Errorf("Failed, Pluck without Table() didn't return any results")
 	}
+
+	DB.Table("blag").Raw(`select name from users`).Pluck("name", &names)
+	if len(names) != 1 {
+		t.Errorf("Failed, Pluck without Table() didn't return any results")
+	}
+	// This succeeds, even though "blag" isn't even a real table.
 }


### PR DESCRIPTION
## Explain your user case and expected results
In gorm v1, I could use Raw().Pluck() into a slice of primitives.  In gorm v2, I must *also* include a call to either Model() or Table(), or the Pluck() doesn't work.  But oddly, it doesn't matter what table name I provide Table()...providing anything to Pluck seems to make it work.

Since the Table()/Model() doesn't seem to actually be necessary if I'm not plucking into structs, I'd expect either
1. Remove the requirement to call Table() or Model() when it isn't necessary, to make Pluck() more backward compatible with v1.
2. Mention in the v2 release notes that Pluck()'s behavior has a breaking change.