### PR TITLE
Composite primary key update failure when calling Save()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,51 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+// Home is an object with a composite primary key (Street, ApartmentNumber, City, State, Zipcode).
+// In the case of an apartment, Steet, City, State, and Zipcode can be the same and the ApartmentNumber is different.
+// However, for a house, an apartment number is optional.
+type Home struct {
+	Street          string `gorm:"primarykey"`
+	ApartmentNumber string `gorm:"primarykey"`
+	City            string `gorm:"primarykey"`
+	State           string `gorm:"primarykey"`
+	Zipcode         string `gorm:"primarykey"`
+	YearBuilt       string
+	MarketStatus    string
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	if DB.Migrator().HasTable(&Home{}) {
+		err := DB.Migrator().DropTable(&Home{})
+		if err != nil {
+			t.Errorf("Error while dropping table Home: %v", err)
+		}
+	}
 
-	DB.Create(&user)
+	err := DB.Migrator().CreateTable(&Home{})
+	if err != nil {
+		t.Errorf("Error while creating table Home: %v", err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	home := Home{
+		Street:          "1111 Main Street",
+		ApartmentNumber: "",
+		City:            "Palo Alto",
+		State:           "CA",
+		Zipcode:         "11111",
+		YearBuilt:       "1990",
+		MarketStatus:    "Listed For Sale",
+	}
+	// Insert a new Home record
+	if err = DB.Save(&home).Error; err != nil {
+		t.Errorf("Error while inserting Home record: %v", err)
+	}
+
+	// Update MarketStatus of the same Home record.
+	home.MarketStatus = "Sold"
+	// Try to save it but this operation fails.
+	// Instead of UPDATE, INSERT is attempted.
+	if err = DB.Save(&home).Error; err != nil {
+		t.Errorf("Error while updating existing Home record: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When a db model object has a composite primary key, db.Save() fails when trying to update an existing record if one of the primary keys a default value. The gorm code seems to do create even if only one primary key has a zero value.

finisher_api.go - Save():

```
case reflect.Struct:
    if err := tx.Statement.Parse(value); err == nil && tx.Statement.Schema != nil {
        for _, pf := range tx.Statement.Schema.PrimaryFields {
            if _, isZero := pf.ValueOf(reflectValue); isZero {
                tx.callbacks.Create().Execute(tx)
                return
            }
        }
```