### PR TITLE
record not found Error logged when using FirstOrCreate()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -10,11 +10,8 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	
+	if err := DB.FirstOrCreate(&user).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
A single FirstOrCreate triggers an Error log when User is not found, despite catching errors. 
It seems there's no way to dismiss this log, except by setting Logger to Silent ...

## Explain your user case and expected results
