### PR TITLE
autoIncrement doesn't work with BIGINT Unsigned

### DIFF
--- a/autoIncrement_test.go
+++ b/autoIncrement_test.go
@@ -4,17 +4,15 @@ import (
 	"testing"
 )
 
+CustomUser{
+		ID uint64 `gorm:"primaryKey;autoIncrement;column:id;type:bigint unsigned;" json:"id"`
+}
+
+
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	DB.AutoMigrate(&CustomUser{})
 }


### PR DESCRIPTION

## Explain your user case and expected results

uint64 primaryKey (BIGINT UNSIGNED) doesn't create AUTO_INCREMENT on MySQL 8.0 despite autoIncrement annotation (doesn't work with "auto_increment" key either).

The only way to make it AutoMigrate with AUTO_INCREMENT is to add this annotation :
ID uint64 `gorm:"primaryKey;autoIncrement;column:id;type:bigint unsigned AUTO_INCREMENT;" json:"id"`

But then, if any Association, it will fail with this error:
"error": "Error occurred when migrating Profile:Error 1075: Incorrect table definition; there can be only one auto column and it must be defined as a key",