### PR TITLE
id suffix problem

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,34 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	type foo struct {
+		gorm.Model
+		BarCID string
+	}
 
-	DB.Create(&user)
+	// Migrate the schema
+	err := DB.AutoMigrate(&foo{})
+	if err != nil {
+		t.Fatal("failed to migrate database")
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// Create
+	err = DB.Create(&foo{BarCID: "some value"}).Error
+	if err != nil {
+		t.Fatal("failed to create model")
+	}
+
+	var m foo
+
+	// Read with expected column name
+	err = DB.First(&m, "bar_cid = ?", "some value").Error // find with BarCID "some value"
+	if err != nil {
+		t.Fatal("can't fetch with expected column name")
+	}
+
+	// Read with actual column name
+	err = DB.First(&m, "bar_c_id = ?", "some value").Error // find with BarCID "some value"
+	if err == nil {
+		t.Fatal("can fetch with unexpected column name")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
A field with the last word ending in "-id" will produce a wrong column name

For example "FooCID" will become "foo_c_id" instead of "foo_cid"

This can be worked around with the "column" tag but it's annoying