### PR TITLE
test: no cache preload in goroutine

### DIFF
--- a/db.go
+++ b/db.go
@@ -32,7 +32,8 @@ func init() {
 			log.Printf("failed to connect database, got error %v\n", err)
 		}
 
-		RunMigrations()
+		// 注释掉这个否则会有缓存，无法复现bug
+		//RunMigrations()
 		if DB.Dialector.Name() == "sqlite" {
 			DB.Exec("PRAGMA foreign_keys = ON")
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/playground
 go 1.14
 
 require (
+	github.com/stretchr/testify v1.5.1
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/driver/postgres v1.0.5
 	gorm.io/driver/sqlite v1.1.3

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,41 @@
 package main
 
 import (
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+// TestPreloadGoroutine goroutine中在没有缓存的情况下使用Preload
+func TestPreloadGoroutine(t *testing.T) {
+	// 这里不要用Create，因为会缓存relations
+	// 把db.go中init()函数中的RunMigrations()注释掉，数据库中保留一些数据来触发Preload
+	var wg sync.WaitGroup
 
-	DB.Create(&user)
+	DB = DB.Where("id = ?", 1)
+	tx := DB.Session(&gorm.Session{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			var user2 []User
+
+			tx = tx.Preload("Team")
+			err := tx.Find(&user2).Error
+
+			ast := assert.New(t)
+			// 这里会报错,Team: unsupported relations
+			// relations是空的
+			ast.Equal(nil, err)
+		}()
 	}
+	wg.Wait()
 }


### PR DESCRIPTION
并发使用preload的时候，如果没有relations的缓存（非并发情况下的缓存）会在parse和clone的时候出现DATA RACE，导致relations都是nil，抛出unsupported relations的错误信息