### PR TITLE
AfterCreate not firing when needed MySQL

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"gorm.io/gorm"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -55,4 +56,18 @@ func TestGORM(t *testing.T) {
 			Name: "First Address",
 		}},
 	})
+
+	var pa PersonAddress
+	DB.First(&pa, "person_id = ? AND home = ?", 1, true)
+
+	if reflect.DeepEqual(pa, PersonAddress{}) {
+		t.Error("Not found, but I should")
+	}
+
+	DB.First(&pa, "person_id = ? AND home = ?", 1, false)
+
+	if !reflect.DeepEqual(pa, PersonAddress{}) {
+		t.Error("Found, but I should not")
+	}
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,58 @@
 package main
 
 import (
+	"fmt"
+	"gorm.io/gorm"
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
+
+type Person struct {
+	ID        int
+	Name      string
+	Addresses []Address `gorm:"many2many:person_addresses;"`
+}
+
+type Address struct {
+	ID   uint
+	Name string
+}
+
+type PersonAddress struct {
+	PersonID  int
+	AddressID int
+	Home      bool
+	CreatedAt time.Time
+	DeletedAt gorm.DeletedAt
+}
+
+func (p *PersonAddress) AfterCreate(db *gorm.DB) error {
+	db.Model(p).Where(p).Update("home", true)
+	return nil
+}
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	DB.AutoMigrate(&Address{})
+	DB.AutoMigrate(&Person{})
+	DB.AutoMigrate(&PersonAddress{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	err := DB.SetupJoinTable(&Person{}, "Addresses", &PersonAddress{})
+
+	if err != nil {
+		fmt.Println(err.Error())
 	}
+
+	DB.Debug().Create(&Person{
+		ID:   1,
+		Name: "Joe",
+		Addresses: []Address{{
+			ID:   1,
+			Name: "First Address",
+		}},
+	})
 }


### PR DESCRIPTION
## Explain your user case and expected results

I expect
```
func (p *PersonAddress) AfterCreate(db *gorm.DB) error {
	db.Model(p).Where(p).Update("home", true)
	return nil
}
```
is executed after insert of `PersonAddress,` as documented [here](https://gorm.io/docs/hooks.html#Creating-an-object) but it is not what happens in MySQL. The query log is:

```
...

2020/11/28 19:27:23 /Users/alessandro/GolandProjects/playground2/main_test.go:50
[8.406ms] [rows:1] INSERT INTO `addresses` (`name`,`id`) VALUES ('First Address',1) ON DUPLICATE KEY UPDATE `id`=`id`

2020/11/28 19:27:23 /Users/alessandro/GolandProjects/playground2/main_test.go:34
[11.990ms] [rows:0] UPDATE `person_addresses` SET `home`=true WHERE `person_addresses`.`person_id` = 1 AND `person_addresses`.`address_id` = 1 AND `person_addresses`.`created_at` = '2020-11-28 19:27:23.207'

2020/11/28 19:27:23 /Users/alessandro/GolandProjects/playground2/main_test.go:50
[28.112ms] [rows:1] INSERT INTO `person_addresses` (`person_id`,`address_id`,`home`,`created_at`,`deleted_at`) VALUES (1,1,false,'2020-11-28 19:27:23.207',NULL) ON DUPLICATE KEY UPDATE `person_id`=`person_id`

2020/11/28 19:27:23 /Users/alessandro/GolandProjects/playground2/main_test.go:50
[66.557ms] [rows:1] INSERT INTO `people` (`name`,`id`) VALUES ('Joe',1)

...
```
