### PR TITLE
Can't get update dest struct info at BeforeSave

### DIFF
--- a/go.mod.bak
+++ b/go.mod.bak
@@ -6,7 +6,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.5 // indirect
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/driver/postgres v1.0.5
-	gorm.io/driver/sqlite v1.1.3
+	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.5
 	gorm.io/gorm v1.20.7
 )

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,22 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	t.Run("20_or_higher_age_validation", func(t *testing.T) {
+		DB.Begin()
+		defer DB.Rollback()
 
-	DB.Create(&user)
+		user := User{
+			Name: "jinzhu",
+			Age:  20,
+		}
+		DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+		err := DB.Model(&user).Updates(User{
+			Age: 19,
+		}).Error
+
+		if err == nil {
+			t.Error("20 or higher age validation doesn't work")
+		}
+	})
 }

--- a/models.go
+++ b/models.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -27,6 +28,13 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+}
+
+func (u User) BeforeSave(tx *gorm.DB) error {
+	if u.Age < 20 {
+		return errors.New("20 or higher age required")
+	}
+	return nil
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

We want to set age validation at BeforeSave hook method, but it doesn't work.
Because we can't get Updates struct info at BeforeUpdate hook function after gorm.io/gorm@v1.20.6.

I guess this change cause this issue.
https://github.com/go-gorm/gorm/commit/4009ec58163b97294633edc19f5d792546cd612c#diff-786fb85249356e0b2d6ef4efc0c31904c88bf8a9e63fc748493ad9c0aa82b7b6L11

Gorm set reflect value of db.Statement.Model at SetupUpdateReflectValue function, so we can't get reflect value of db.Statement.Dest at BeforeUpdate function.
https://github.com/go-gorm/gorm/blob/v1.20.6/callbacks/update.go#L15