### PR TITLE
GORM migration forces a not null constraint on self-referencing foreign key in Postgres

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/driver/postgres v1.0.5
-	gorm.io/driver/sqlite v1.1.3
+	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.5
 	gorm.io/gorm v1.20.7
 )

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: postgres
+// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}

--- a/models.go
+++ b/models.go
@@ -12,7 +12,7 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
+	ID        uint `gorm:"type:smallserial;primarykey"`
 	Name      string
 	Age       uint
 	Birthday  *time.Time
@@ -27,6 +27,9 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
 type Account struct {

--- a/models.go
+++ b/models.go
@@ -12,7 +12,7 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	ID        uint `gorm:"type:smallserial;primarykey"`
+	ID        uint        `gorm:"type:smallserial;primarykey"`
 	Name      string
 	Age       uint
 	Birthday  *time.Time
@@ -21,7 +21,7 @@ type User struct {
 	Toys      []Toy `gorm:"polymorphic:Owner"`
 	CompanyID *int
 	Company   Company
-	ManagerID *uint
+	ManagerID *uint      `gorm:"type:smallint"`
 	Manager   *User
 	Team      []User     `gorm:"foreignkey:ManagerID"`
 	Languages []Language `gorm:"many2many:UserSpeak"`


### PR DESCRIPTION
## Explain your user case and expected results
If a GORM model's primary key column type is one of the `serial` types and it has self-referencing foreign key, using GORM's AutoMigrate feature will force a not null constraint on the foreign key, even though the foreign key field isn't tagged as `not null`.