### PR TITLE
Associations creation with composite primary key

### DIFF
--- a/db.go
+++ b/db.go
@@ -53,7 +53,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
-			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	case "sqlserver":
@@ -83,11 +83,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Project{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
-
-	DB.Migrator().DropTable("user_friends", "user_speaks")
 
 	if err = DB.Migrator().DropTable(allModels...); err != nil {
 		log.Printf("Failed to drop table, got error %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,36 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		UnitID: 8,
+		ID:     1,
+		Name:   "Andrei",
+		Projects: []Project{
+			{
+				ID:    1,
+				Title: "First project",
+			},
+			{
+				ID:    2,
+				Title: "Second project",
+			},
+		},
+	}
 
-	DB.Create(&user)
+	if err := DB.Create(&user).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Where(&User{UnitID: user.UnitID, ID: user.ID}).First(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	var projects []Project
+	if err := DB.Where(&Project{UnitID: user.UnitID, UserID: user.ID}).Find(&projects).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(projects) != len(user.Projects) {
+		t.Errorf("Failed, projects length should be %d, got %d", len(user.Projects), len(result.Projects))
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,30 @@
 package main
 
 import (
-	"database/sql"
 	"time"
 
 	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
+// User has many projects
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	UnitID    uint `gorm:"primaryKey"`
+	ID        uint `gorm:"primaryKey;autoIncrement:false"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+
+	Name     string
+	Projects []Project `gorm:"foreignKey:UnitID,UserID"`
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
+type Project struct {
+	UnitID    uint `gorm:"primaryKey"`
+	ID        uint `gorm:"primaryKey;autoIncrement:false"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
 
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	UserID uint
+	Title  string
 }


### PR DESCRIPTION
User has composite primary key (UnitID, ID).
Project also has composite primary key (UnitID, ID).
User has many projects.

When creating a User record from a User structure containing associated projects, I expect that the Project records should also be created without errors.

This case causes errors in sqlite and postgres.