### PR TITLE
"type" tag is ignored when also a foreign key

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,5 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	// No tests needed, the auto migration will fail
 }

--- a/models.go
+++ b/models.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"time"
 
 	"gorm.io/gorm"
 )
@@ -13,20 +12,9 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
+	Name      string `gorm:"type:varchar(64)"`
+	CompanyID string `gorm:"type:varchar(64)"`
 	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
 }
 
 type Account struct {
@@ -50,7 +38,7 @@ type Toy struct {
 }
 
 type Company struct {
-	ID   int
+	ID   string `gorm:"primarykey"`
 	Name string
 }
 


### PR DESCRIPTION
If you run the tests with the following command:

```bash
GORM_DIALECT=mysql go test
```

The automigration will fail because of an error on the User model, which is the following:

```go
type User struct {
	gorm.Model
	Name      string `gorm:"type:varchar(64)"`
	CompanyID string `gorm:"type:varchar(64)"`
	Company   Company
}
```

This is the error log:

```
Error 1170: BLOB/TEXT column 'company_id' used in key specification without a key length

[0.830ms] [rows:0] CREATE TABLE `users` (`id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL,
`updated_at` datetime(3) NULL,`deleted_at` datetime(3) NULL,`name` varchar(64),`company_id` longtext,
PRIMARY KEY (`id`),INDEX idx_users_deleted_at (`deleted_at`),
CONSTRAINT `fk_users_company` FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`))
```



As you can see, the `name` field is created as a `varchar(64)`, as expected.

However, the `company_id` field, which has the exact same type / tag, is created as a `longtext` instead of a `varchar(64)`, which is the source of the MySQL error.

The only difference between `company_id` and `name` is that the first one is a foreign key, and not the other.
