### PR TITLE
String foreign keys cannot be migrated in MySQL

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,5 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	// No tests needed, the auto migration will fail
 }

--- a/models.go
+++ b/models.go
@@ -19,7 +19,7 @@ type User struct {
 	Account   Account
 	Pets      []*Pet
 	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
+	CompanyID *string
 	Company   Company
 	ManagerID *uint
 	Manager   *User
@@ -50,7 +50,7 @@ type Toy struct {
 }
 
 type Company struct {
-	ID   int
+	ID   string
 	Name string
 }
 


### PR DESCRIPTION
I run the tests with `GORM_DIALECT=mysql go test`.

If I set the company ID to type `string`, the auto-migration creates `user.company_id` as a `longtext`, which is not suitable for a foreign key constraint (in MySQL). A varchar would be a better option.

Error log:

```
Error 1170: BLOB/TEXT column 'company_id' used in key specification without a key length

[1.189ms] [rows:0] CREATE TABLE `users` (`id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,`deleted_at` datetime(3) NULL,`name` longtext,`age` bigint unsigned,`birthday` datetime(3) NULL,`company_id` longtext,`manager_id` bigint unsigned,`active` boolean,PRIMARY KEY (`id`),INDEX idx_users_deleted_at (`deleted_at`),CONSTRAINT `fk_users_team` FOREIGN KEY (`manager_id`) REFERENCES `users`(`id`),CONSTRAINT `fk_users_company` FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`),CONSTRAINT `fk_users_manager` FOREIGN KEY (`manager_id`) REFERENCES `users`(`id`))

Failed to auto migrate, but got error Error 1170: BLOB/TEXT column 'company_id' used in key specification without a key length
```

N.B: I know can solve the problem by using the `size` tag in `User.CompanyID`, but that is not intuitive at all, and I think GORM should handle it natively.