### PR TITLE
Add failed test case for splitting raw read query while using dbresolver

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,9 +13,11 @@ import (
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"gorm.io/plugin/dbresolver"
 )
 
 var DB *gorm.DB
+var ReadDB *gorm.DB
 
 func init() {
 	var err error
@@ -38,6 +40,12 @@ func init() {
 		}
 
 		DB.Logger = DB.Logger.LogMode(logger.Info)
+
+		ReadDB = initReadDB()
+		if DB.Dialector.Name() == "sqlite" {
+			ReadDB.Exec("PRAGMA foreign_keys = ON")
+		}
+		ReadDB.Logger = ReadDB.Logger.LogMode(logger.Info)
 	}
 }
 
@@ -105,4 +113,86 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+}
+
+func initReadDB() (db *gorm.DB) {
+	var err error
+
+	dbDSN := os.Getenv("GORM_DSN")
+	dbDSN2 := os.Getenv("GORM_DSN_READ")
+	switch os.Getenv("GORM_DIALECT") {
+	case "mysql":
+		if dbDSN == "" {
+			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
+		}
+		if dbDSN2 == "" {
+			dbDSN2 = "gorm:gorm@tcp(localhost:9911)/gorm?charset=utf8&parseTime=True&loc=Local"
+		}
+		db, err = gorm.Open(mysql.Open(dbDSN2), &gorm.Config{})
+		if err == nil {
+			err = db.Use(dbresolver.Register(dbresolver.Config{
+				Sources:  []gorm.Dialector{mysql.Open(dbDSN)},
+				Replicas: []gorm.Dialector{mysql.Open(dbDSN2)},
+			}, "users"))
+		}
+	case "postgres":
+		if dbDSN == "" {
+			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+		}
+		if dbDSN2 == "" {
+			dbDSN2 = "user=gorm password=gorm host=localhost dbname=gorm port=9921 sslmode=disable TimeZone=Asia/Shanghai"
+		}
+		db, err = gorm.Open(postgres.Open(dbDSN2), &gorm.Config{})
+		if err == nil {
+			err = db.Use(dbresolver.Register(dbresolver.Config{
+				Sources:  []gorm.Dialector{postgres.Open(dbDSN)},
+				Replicas: []gorm.Dialector{postgres.Open(dbDSN2)},
+			}, "users"))
+		}
+
+	case "sqlserver":
+		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
+		// CREATE DATABASE gorm;
+		// USE gorm;
+		// CREATE USER gorm FROM LOGIN gorm;
+		// sp_changedbowner 'gorm';
+		if dbDSN == "" {
+			dbDSN = "sqlserver://gorm:LoremIpsum86@localhost:9930?database=gorm"
+		}
+		if dbDSN2 == "" {
+			dbDSN2 = "sqlserver://gorm:LoremIpsum86@localhost:9931?database=gorm"
+		}
+		db, err = gorm.Open(sqlserver.Open(dbDSN2), &gorm.Config{})
+		if err == nil {
+			err = db.Use(dbresolver.Register(dbresolver.Config{
+				Sources:  []gorm.Dialector{sqlserver.Open(dbDSN)},
+				Replicas: []gorm.Dialector{sqlserver.Open(dbDSN2)},
+			}, "users"))
+		}
+
+	default:
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db1")), &gorm.Config{})
+		if err == nil {
+			err = db.Use(dbresolver.Register(dbresolver.Config{
+				Sources:  []gorm.Dialector{sqlite.Open(filepath.Join(os.TempDir(), "gorm.db"))},
+				Replicas: []gorm.Dialector{sqlite.Open(filepath.Join(os.TempDir(), "gorm.db1"))},
+			}, "users"))
+		}
+	}
+	if err != nil {
+		log.Printf("failed to connect database, got error %v\n", err)
+		os.Exit(1)
+	}
+
+	if err = db.Migrator().DropTable(&User{}); err != nil {
+		log.Printf("Failed to drop table, got error %v\n", err)
+		os.Exit(1)
+	}
+
+	if err = db.AutoMigrate(&User{}); err != nil {
+		log.Printf("Failed to auto migrate, but got error %v\n", err)
+		os.Exit(1)
+	}
+
+	return
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,32 @@ services:
       - MSSQL_DB=gorm
       - MSSQL_USER=gorm
       - MSSQL_PASSWORD=LoremIpsum86
+  mysql_read:
+    image: 'mysql:latest'
+    ports:
+      - 9911:3306
+    environment:
+      - MYSQL_DATABASE=gorm
+      - MYSQL_USER=gorm
+      - MYSQL_PASSWORD=gorm
+      - MYSQL_RANDOM_ROOT_PASSWORD="yes"
+  postgres_read:
+    image: 'postgres:latest'
+    ports:
+      - 9921:5432
+    environment:
+      - TZ=Asia/Shanghai
+      - POSTGRES_DB=gorm
+      - POSTGRES_USER=gorm
+      - POSTGRES_PASSWORD=gorm
+  mssql_read:
+    image: 'mcmoe/mssqldocker:latest'
+    ports:
+      - 9931:1433
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=LoremIpsum86
+      - MSSQL_DB=gorm
+      - MSSQL_USER=gorm
+      - MSSQL_PASSWORD=LoremIpsum86
 

--- a/main_test.go
+++ b/main_test.go
@@ -12,9 +12,18 @@ func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
+	ReadDB.Create(&User{Name: "jinzhu-read"})
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	result.Name = ""
+	if err := DB.Raw(`
+SELECT name FROM users
+WHERE name = ?
+`, "jinzhu-read").Row().Scan(&result.Name); err == nil || result.Name != "" {
+		t.Errorf("Failed, did not go to read db, name %q", result.Name)
 	}
 }


### PR DESCRIPTION
xref: https://github.com/go-gorm/dbresolver/issues/19

## Explain your user case and expected results

While using `gorm.io/plugin/dbresolver` to split read-write, raw query having whitespace(s) as prefix should go to read server.

```go
import (
  "gorm.io/gorm"
  "gorm.io/plugin/dbresolver"
  "gorm.io/driver/mysql"
)

DB, err := gorm.Open(mysql.Open("db1_dsn"), &gorm.Config{})

DB.Use(dbresolver.Register(dbresolver.Config{
  // use `db1` as sources, `db2` as replicas for 
  Sources:  []gorm.Dialector{mysql.Open("db1_dsn")},
  Replicas: []gorm.Dialector{mysql.Open("db2_dsn")}
}, "users"))


// ...

readDB, err := gorm.Open(mysql.Open("db2_dsn"), &gorm.Config{})
if err != nil {
  // handle error
}

readDB.Create(&User{Name: "read"})

// this query should go to the read db with db2_dsn
DB.Raw(`
select name from users
where name = ?
`, "read").Row().Scan(&name)

```

This query should go to the read db with `db2_dsn`, but the current dbresolver sends it to the write db with `db1_dsn`.
