### PR TITLE
Empty Model in Callback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	gorm.io/driver/postgres v1.0.5
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.5
-	gorm.io/gorm v1.20.8
+	gorm.io/gorm v1.20.11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,56 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"strconv"
 	"testing"
 )
+
+type Model struct {
+	ID       uint64 `gorm:"primaryKey;autoIncrement"`
+	Title    string `gorm:"size:100;not null"`
+	TypeEnum int    `gorm:"-"`
+	Type     string `gorm:"size:100"`
+}
+
+func (m *Model) BeforeSave(db *gorm.DB) error {
+	if m.TypeEnum == 0 {
+		fmt.Println(*m) // see the console output, its completely empty
+		return errors.New("illegal type")
+	}
+	db.Statement.SetColumn("Type", strconv.Itoa(m.TypeEnum))
+	return nil
+}
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	err := DB.AutoMigrate(&Model{})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
 
-	DB.Create(&user)
+	m := &Model{
+		Title:    "New",
+		TypeEnum: 1,
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// Create the Model
+	if err = DB.Create(m).Error; err != nil {
+		t.FailNow()
+	}
+
+	// Update the Model
+	m.TypeEnum = 3
+
+	// Save the Model
+	err = DB.Model(&Model{}).Where("id = ?", m.ID).Updates(m).Error
+	if err != nil { // There is an "illegal type" error, because the model in the callback is empty
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The BeforeSave(db) callback receives an empty model in the DB.Updates(model) call, instead of the model which is updated. This leads to an error.
This worked before (v1.20.5), but stopped working afterwards (v1.20.6+)