### PR TITLE
Error with COUNT() when making a query containing a count.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,21 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestCount(t *testing.T) {
+	query := DB.Model(UserWithPetCount{}).Select("users.*, COUNT(pets.id) AS pet_count").
+		Joins("LEFT JOIN pets ON pets.user_id = users.id").
+		Group("users.id")
+
+	var count int64 
+
+	if err := query.Count(&count).Error; err != nil {
+		t.Errorf("Failed count query, got error: %v", err)
+	}
+	
+	var users []UserWithPetCount
+
+	if err := query.Limit(5).Find(&users).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -29,6 +29,15 @@ type User struct {
 	Active    bool
 }
 
+type UserWithPetCount struct {
+	User 
+	PetCount int64
+}
+
+func (UserWithPetCount) TableName() string {
+	return "users"
+}
+
 type Account struct {
 	gorm.Model
 	UserID sql.NullInt64


### PR DESCRIPTION
## Explain your user case and expected results
I believe this was a regression introduced in the fix for #219. Updating to the latest version of GORM, a query I previously had used for pagination appears to be failing.

The error I get looks like:

```
expected 11 destination arguments in Scan, not 1
```