### PR TITLE
Example of multi-tier hook issue

### DIFF
--- a/db.go
+++ b/db.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -83,7 +84,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{
+		&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{},
+		&TwoTieredEntryDb{}, &TwoTieredLinkDb{},
+		&ThreeTieredParentDb{}, &ThreeTieredEntryDb{}, &ThreeTieredLinkDb{},
+	}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module gorm.io/playground
 go 1.14
 
 require (
+	github.com/stretchr/testify v1.7.0
 	gorm.io/driver/mysql v1.0.3
-	gorm.io/driver/postgres v1.0.5
+	gorm.io/driver/postgres v1.0.6
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.5
 	gorm.io/gorm v1.20.8

--- a/three_tiered.go
+++ b/three_tiered.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"gorm.io/gorm"
+)
+
+type ThreeTieredParent struct {
+	ParentPK uint64              `gorm:"primary_key;autoIncrement:false;column:parent_pk;type:INT8;"`
+	Entries  []*ThreeTieredEntry `gorm:"-"`
+}
+
+type ThreeTieredParentDb struct {
+	ThreeTieredParent
+	EntriesDb []*ThreeTieredEntryDb `gorm:"foreignKey:ParentPK;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+}
+
+// TableName overrides the table name used by ParentDb to `parents`.
+func (ThreeTieredParentDb) TableName() string {
+	return "three_parents"
+}
+
+func (tdb *ThreeTieredParentDb) AfterFind(tx *gorm.DB) (err error) {
+	if tx.Error == nil {
+		for _, edb := range tdb.EntriesDb {
+			edb.ParentPK = tdb.ParentPK
+			tdb.Entries = append(tdb.Entries, &edb.ThreeTieredEntry)
+		}
+		tdb.EntriesDb = nil
+	}
+	return
+}
+
+func (tdb *ThreeTieredParentDb) BeforeSave(_ *gorm.DB) (err error) {
+	for _, e := range tdb.Entries {
+		tdb.EntriesDb = append(tdb.EntriesDb, &ThreeTieredEntryDb{ThreeTieredEntry: *e, ParentPK: tdb.ParentPK})
+	}
+	return
+}
+
+func (tdb *ThreeTieredParentDb) AfterSave(_ *gorm.DB) (err error) {
+	tdb.EntriesDb = nil
+	return
+}
+
+// Entry represents an entry.
+type ThreeTieredEntry struct {
+	EntryPK uint64           `gorm:"primary_key;autoIncrement:false;column:entry_pk;type:INT8;"`
+	Links   map[string]int64 `gorm:"-"`
+}
+
+// ThreeTieredEntryDb holds one row from the entries table.
+type ThreeTieredEntryDb struct {
+	ThreeTieredEntry
+	ParentPK uint64              `gorm:"column:parent_pk;type:INT8;"`
+	LinksDb  []ThreeTieredLinkDb `gorm:"foreignKey:EntryPK;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+}
+
+// TableName overrides the table name used by EntryDb to `entries`.
+func (ThreeTieredEntryDb) TableName() string {
+	return "three_entries"
+}
+
+func (edb *ThreeTieredEntryDb) AfterFind(tx *gorm.DB) (err error) {
+	if tx.Error == nil {
+		edb.Links = make(map[string]int64)
+		for _, l := range edb.LinksDb {
+			if l.Key == "" {
+				return fmt.Errorf("empty key for entry links")
+			}
+			edb.Links[l.Key] = l.Link
+		}
+		edb.LinksDb = nil
+	}
+	return
+}
+
+func (edb *ThreeTieredEntryDb) BeforeSave(_ *gorm.DB) (err error) {
+	var sorted []string
+	for key := range edb.Links {
+		sorted = append(sorted, key)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	for _, key := range sorted {
+		edb.LinksDb = append(edb.LinksDb, ThreeTieredLinkDb{EntryPK: edb.EntryPK, Key: key, Link: edb.Links[key]})
+	}
+	return
+}
+
+func (edb *ThreeTieredEntryDb) AfterSave(_ *gorm.DB) (err error) {
+	edb.LinksDb = nil
+	return
+}
+
+// ThreeTieredLinkDb holds one row from the links table.
+type ThreeTieredLinkDb struct {
+	EntryPK uint64 `gorm:"primary_key;autoIncrement:false;column:entry_pk;type:INT8;"`
+	Key     string `gorm:"primary_key;autoIncrement:false;column:key;type:VARCHAR;size:64;"`
+	Link    int64  `gorm:"column:link;type:INT4;"`
+}
+
+// TableName overrides the table name used by ThreeTieredLinkDb to `links`.
+func (ThreeTieredLinkDb) TableName() string {
+	return "three_links"
+}

--- a/three_tiered_test.go
+++ b/three_tiered_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThreeTieredDb(t *testing.T) {
+	var cttpd ThreeTieredParentDb
+	cttpd.ParentPK = 1
+
+	p := &cttpd.ThreeTieredParent
+	p.Entries = []*ThreeTieredEntry{{
+		EntryPK: 123,
+		Links:   map[string]int64{"one": 1, "two": 2, "three": 3},
+	}}
+
+	result := DB.Create(&cttpd)
+	assert.NoError(t, result.Error)
+
+	var lttpd ThreeTieredParentDb
+	result = DB.Preload("EntriesDb.LinksDb").Find(&lttpd, 1)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, ThreeTieredParentDb{
+		ThreeTieredParent: ThreeTieredParent{
+			ParentPK: 1,
+			Entries: []*ThreeTieredEntry{{
+				EntryPK: 123,
+				Links:   map[string]int64{"one": 1, "two": 2, "three": 3},
+			}}},
+	}, lttpd)
+}

--- a/two_tiered.go
+++ b/two_tiered.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"gorm.io/gorm"
+)
+
+// TwoTieredEntry represents an entry.
+type TwoTieredEntry struct {
+	EntryPK uint64           `gorm:"primary_key;autoIncrement:false;column:entry_pk;type:INT8;"`
+	Links   map[string]int64 `gorm:"-"`
+}
+
+// TwoTieredEntryDb holds one row from the entries table.
+type TwoTieredEntryDb struct {
+	TwoTieredEntry
+	LinksDb  []TwoTieredLinkDb `gorm:"foreignKey:EntryPK;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+}
+
+// TableName overrides the table name used by TwoTieredEntryDb to `entries`.
+func (TwoTieredEntryDb) TableName() string {
+	return "two_entries"
+}
+
+func (edb *TwoTieredEntryDb) AfterFind(tx *gorm.DB) (err error) {
+	if tx.Error == nil {
+		edb.Links = make(map[string]int64)
+		for _, l := range edb.LinksDb {
+			if l.Key == "" {
+				return fmt.Errorf("empty key for entry links")
+			}
+			edb.Links[l.Key] = l.Link
+		}
+		edb.LinksDb = nil
+	}
+	return
+}
+
+func (edb *TwoTieredEntryDb) BeforeSave(_ *gorm.DB) (err error) {
+	var sorted []string
+	for key := range edb.Links {
+		sorted = append(sorted, key)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	for _, key := range sorted {
+		edb.LinksDb = append(edb.LinksDb, TwoTieredLinkDb{EntryPK: edb.EntryPK, Key: key, Link: edb.Links[key]})
+	}
+	return
+}
+
+func (edb *TwoTieredEntryDb) AfterSave(_ *gorm.DB) (err error) {
+	edb.LinksDb = nil
+	return
+}
+
+// TwoTieredLinkDb holds one row from the links table.
+type TwoTieredLinkDb struct {
+	EntryPK uint64 `gorm:"primary_key;autoIncrement:false;column:entry_pk;type:INT8;"`
+	Key     string `gorm:"primary_key;autoIncrement:false;column:key;type:VARCHAR;size:64;"`
+	Link    int64  `gorm:"column:link;type:INT4;"`
+}
+
+// TableName overrides the table name used by LinkDb to `links`.
+func (TwoTieredLinkDb) TableName() string {
+	return "two_links"
+}

--- a/two_tiered_test.go
+++ b/two_tiered_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTwoTieredEntryDb(t *testing.T) {
+	var ctted TwoTieredEntryDb
+
+	e := &ctted.TwoTieredEntry
+	e.EntryPK = 123
+	e.Links = map[string]int64{"one": 1, "two": 2, "three": 3}
+
+	result := DB.Create(&ctted)
+	assert.NoError(t, result.Error)
+
+	var ltted TwoTieredEntryDb
+	result = DB.Preload("LinksDb").Find(&ltted, 123)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, TwoTieredEntryDb{
+		TwoTieredEntry: TwoTieredEntry{
+			EntryPK: 123,
+			Links:   map[string]int64{"one": 1, "two": 2, "three": 3},
+		},
+	}, ltted)
+}


### PR DESCRIPTION
## Explain your user case and expected results

The two-tiered example behaves as expected.  Here, the `AfterFind` hook for `TwoTieredEntry` is called **after** all its constituent parts are loaded.

The three-tiered example does not behave as expected.  In this example, the `AfterFind` hook for `ThreeTieredEntry` is called **before** all its constituent parts are loaded.