### PR TITLE
Reproduce automigrate error shadowing 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/playground
 go 1.14
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/driver/postgres v1.0.5
 	gorm.io/driver/sqlite v1.1.4

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"errors"
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -17,4 +21,42 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+type Model struct {
+	gorm.Model
+}
+
+func TestAutomigrate(t *testing.T) {
+	dbMock, sqlMock, err := sqlmock.New()
+	if err != nil {
+		t.Errorf("sqlmock could not be created")
+	}
+	defer func() {
+		if err := sqlMock.ExpectationsWereMet(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbMock}), &gorm.Config{})
+	if err != nil {
+		t.Errorf("db could not be created")
+	}
+
+	// This test passing would be the expected behaviour
+	t.Run("fail on create table", func(t *testing.T) {
+		errMsg := "sql error"
+		sqlMock.ExpectExec("CREATE TABLE").WillReturnError(errors.New(errMsg))
+		// uncomment this will make the test pass
+		//sqlMock.ExpectExec("CREATE INDEX").WillReturnError(errors.New(errMsg))
+
+		err = db.AutoMigrate(&Model{})
+		if err == nil {
+			t.Errorf("expected migration to return error")
+		}
+
+		if err.Error() != errMsg {
+			t.Errorf("expected migration failed with %s, but got %s", errMsg, err.Error())
+		}
+	})
 }


### PR DESCRIPTION
## Explain your user case and expected results

When using the auto migration, there is an internal option `CreateIndexAfterCreateTable` to create indices with
the `create table` statement or separate. For example the `postgres` driver is using `CreateIndexAfterCreateTable=true`.

The implementation in `migrator.go` with defer the index creation but shadows the error result from statements running
before, like the `create table`.

Current implementation:

```go
if m.CreateIndexAfterCreateTable {
    defer func(value interface{}, name string) {
        errr = tx.Migrator().CreateIndex(value, name)
    }(value, idx.Name)
}
```

Link to code: https://github.com/go-gorm/gorm/blob/9790103e68e4072ada9b0cf17f2e00fc3ac036e8/migrator/migrator.go#L184

The `errr` is already used by the `create table` statement (or other `create index` calls) and could contain an error,
but that's not checked. Instead, it will call all `create index` and override `errr` every time, so that the last
call wins.

In the end you will have the error from the last `create index` returned instead of `create table`, what is not very
useful while debugging.

My proposed solution:

```go
if m.CreateIndexAfterCreateTable {
    defer func(value interface{}, name string) {
    	if errr == nil { // check for existing error
            errr = tx.Migrator().CreateIndex(value, name)
        }
    }(value, idx.Name)
}
```