### PR TITLE
Default value has no effect on UPDATE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.14
 
 require (
-	gorm.io/driver/mysql v1.0.3
-	gorm.io/driver/postgres v1.0.5
+	gorm.io/driver/mysql v1.0.4
+	gorm.io/driver/postgres v1.0.7
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.5
-	gorm.io/gorm v1.20.8
+	gorm.io/driver/sqlserver v1.0.6
+	gorm.io/gorm v1.20.12
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,23 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+// Test inserts and updates the user. Default for column Age is null in the model.
+func TestUpdateDefaultValue(t *testing.T) {
+	user := User{Name: "fblass"}
+
+	DB.Save(&user)
+
+	var result User
+	if err := DB.Where("age is null").First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed insert, got error: %v", err)
+	}
+
+	user.Name = "f-blass"
+	DB.Save(&user)
+
+	var resultUpdated User
+	if err := DB.Where("age is null").First(&resultUpdated, user.ID).Error; err != nil {
+		t.Errorf("Failed on update, got error: %v", err)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -14,7 +14,7 @@ import (
 type User struct {
 	gorm.Model
 	Name      string
-	Age       uint
+	Age       uint `gorm:"default:null"`
 	Birthday  *time.Time
 	Account   Account
 	Pets      []*Pet


### PR DESCRIPTION
I annotated some columns in my model with e.g. `gorm:"default:null"`
This works great for INSERT with db.Save(), however if the entry already exists and GORM decides to perform an UPDATE the default value has no effect.

Expected: 
```sql
UPDATE `users` SET `created_at`="2021-01-27 14:36:37.253",`updated_at`="2021-01-27 14:36:37.254",`deleted_at`=NULL,`name`="f-blass",`age`=NULL,`birthday`=NULL,`company_id`=NULL,`manager_id`=NULL,`active`=false WHERE `id` = 1 
```

Got: 
```sql
UPDATE `users` SET `created_at`="2021-01-27 14:36:37.253",`updated_at`="2021-01-27 14:36:37.254",`deleted_at`=NULL,`name`="f-blass",`age`=0,`birthday`=NULL,`company_id`=NULL,`manager_id`=NULL,`active`=false WHERE `id` = 1
```