### PR TITLE
test: float number set scale  tag

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,16 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	points := 16.37
+	user := User{Name: "jinzhu", Points:points}
 
 	DB.Create(&user)
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+    if result.Points != points {
+		t.Errorf("Failed, points should be %f, but is %f ", points, result.Points)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Points    float64    `gorm:"precision:16;scale:2"`
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results
I added a `float64` field named  `Points` to the l `User` model with this declaration:
``` go
Points    float64    `gorm:"precision:16;scale:2"`
```
when I save a floating number like `16.73`, the value saved in database is `16`. The `scale` tag in declaration does not work.