### PR TITLE
Show difference between subquery types

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -28,9 +28,9 @@ func TestSubQueryRaw(t *testing.T) {
 	var users []*User
 	err := q.Find(&users).Error
 
-	if err == nil {
-		t.Fail()
-	}
+	//if err == nil {
+	//	t.Fail()
+	//}
 
 	fmt.Printf("%v", err)
 	//no such table: ---


### PR DESCRIPTION
TestSubQueryRaw shows that an error occurs, and unexpected SQL,
when a sub query is made using statement built using the .Raw
method.

TestSubQueryBuilder shows the equivalent expected behavior.

In this simple example there would be no reason not to just use
the normal GORM builder, or just a String for the subquery. In
more complex usecases we still would like to use GORM's API
in order to leverage params/args, and general code reuse. Raw
is used to use the UNION operator, for example.

## Explain your user case and expected results
