### PR TITLE
Combination of Belongs-To and Has-Many unexpectedly generate duped constraints

### DIFF
--- a/models.go
+++ b/models.go
@@ -38,6 +38,7 @@ type Account struct {
 type Pet struct {
 	gorm.Model
 	UserID *uint
+	User User
 	Name   string
 	Toy    Toy `gorm:"polymorphic:Owner;"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

Bidirectional Belongs-To and Has-Many associations unexpectedly generate duped constraints that can be unified.

```go
type User struct {
	gorm.Model
	Pets      []*Pet
}

type Pet struct {
	gorm.Model
	UserID *uint
	User User
}
```

```shell
$ ./test.sh
$ docker-compose exec mysql mysql -ugorm -pgorm gorm -e "SHOW CREATE TABLE pets"
...
CREATE TABLE `pets` (
  CONSTRAINT `fk_pets_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
  CONSTRAINT `fk_users_pets` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
```