### PR TITLE
GORM Raw query failing if where clause is on time interval

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+        "time"
 	"testing"
 )
 
@@ -17,4 +18,11 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+        time.Sleep(5 * time.Second)
+
+        r := DB.Exec("delete from users where created_at < now() - interval '? sec'", 2)
+        if r.Error != nil {
+           t.Errorf("Failed, got error: %v", r.Error)
+        }
 }


### PR DESCRIPTION
I have a table where I want to delete entries which are older than some interval (60 seconds, 1 hour, 1 day etc..).
I am trying to use the following and it fails.

```2021/02/17 09:28:33 /home/vinod/gorm-playground/playground/main_test.go:24 expected 0 arguments, got 1
[0.950ms] [rows:0] delete from users where created_at < now() - interval '2 sec'
--- FAIL: TestGORM (5.01s)
    main_test.go:26: Failed, got error: expected 0 arguments, got 1
FAIL
exit status 1
FAIL	gorm.io/playground	5.323s
```