### PR TITLE
After calling Create/Updates api, it can't find the latest data in db with update_at time or create_at time

### DIFF
--- a/go.mod.bak
+++ b/go.mod.bak
@@ -1,0 +1,13 @@
+module gorm.io/playground
+
+go 1.14
+
+require (
+	gorm.io/driver/mysql v1.0.4
+	gorm.io/driver/postgres v1.0.8
+	gorm.io/driver/sqlite v1.1.4
+	gorm.io/driver/sqlserver v1.0.6
+	gorm.io/gorm v1.20.12
+)
+
+replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -13,12 +13,12 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	if err := DB.Updates(user).Error; err != nil {
+	if err := DB.Updates(&user).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
 	var result User
-	if err := DB.Where(user).Take(&result).Error; err != nil {
+	if err := DB.Where(&user).Take(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,12 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
+	if err := DB.Updates(user).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Where(user).Take(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
For example: when we call updates method, `user`.`update_at` is `"2021-02-26 20:47:16.823720459Z"` .
But the `UPDATE` sql uses `"update_at"="2021-02-26 20:47:16.824Z"`, and `SELECT` sql uses `"update_at"="2021-02-26 20:47:16.823Z"`

`update_at` is not consistent.

I think `update_at` should be consistent. And it should be no error for this case
