### PR TITLE
Demonstrate failing query with Joins and (?)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"testing"
 )
 
@@ -8,13 +9,68 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
+func TestInWithParenthesis(t *testing.T) {
 	user := User{Name: "jinzhu"}
+	if err := DB.Create(&user).Error; err != nil {
+		// Does not fail
+		t.Errorf("Failed, got error: %v", err)
+	}
 
-	DB.Create(&user)
+	acount := Account{Number: "foo", UserID: sql.NullInt64{
+		Int64: int64(user.ID),
+		Valid: true,
+	}}
+	DB.Create(&acount)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var accounts []Account
+	q := DB.Select("accounts.*").Table("accounts").Joins("left join users on accounts.user_id = users.id and accounts.id IN (?)", []uint{1, 2})
+	q = q.Find(&accounts)
+
+	if err := q.Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestInWithoutParenthesis(t *testing.T) {
+	user := User{Name: "jinzhu"}
+	if err := DB.Create(&user).Error; err != nil {
+		// Does not fail
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	acount := Account{Number: "foo", UserID: sql.NullInt64{
+		Int64: int64(user.ID),
+		Valid: true,
+	}}
+	DB.Create(&acount)
+
+	var accounts []Account
+	q := DB.Select("accounts.*").Table("accounts").Joins("left join users on accounts.user_id = users.id and accounts.id IN ?", []uint{1, 2})
+	q = q.Find(&accounts)
+
+	if err := q.Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestWhereInWithParenthesis(t *testing.T) {
+	user := User{Name: "jinzhu"}
+	if err := DB.Create(&user).Error; err != nil {
+		// Does not fail
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	acount := Account{Number: "foo", UserID: sql.NullInt64{
+		Int64: int64(user.ID),
+		Valid: true,
+	}}
+	DB.Create(&acount)
+
+	var accounts []Account
+	q := DB.Select("accounts.*").Table("accounts").Where("accounts.id IN (?)", []uint{1, 2})
+	q = q.Find(&accounts)
+
+	if err := q.Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
* Writing a query with `IN (?)` works for a normal where clause, but
not a Joins (see TestWhereInWithParenthesis).
* Writing a query with a join and `IN ?` works for the test setup
I have demonstrated between the tests (see TestInWithoutParenthesis).
* Writing a query with a join and `IN (?)` causes an error.
  * This same style query does work in GORM V1 as well.
* Other aspects of the query, like the arbitrary IDs and the join table
not actually being used in the query, do not seem to make any difference.

## Explain your user case and expected results
