### PR TITLE
named params in section API

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"database/sql"
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +15,74 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var result = struct {
+		RangeOne int
+		RangeTwo int
+	}{}
+
+	// using these util function to get the values based at runtime based on current timestamp
+	rangeOneStart, rangeOneEnd := getDailyRange(time.Now())
+	rangeTwoStart, rangeTwoEnd := getYearlyRange(time.Now())
+
+	err := DB.Model(user).
+		Select("sum( if( created_at >= @rangeOneStart AND created_at < @rangeOneEnd, 1, 0 )) as range_one, "+
+			"sum( if( created_at >= @rangeTwoStart AND created_at < @rangeTwoEnd, 1, 0 )) as range_two",
+		sql.Named("rangeOneStart", rangeOneStart),
+		sql.Named("rangeOneEnd", rangeOneEnd),
+		sql.Named("rangeTwoStart", rangeTwoStart),
+		sql.Named("rangeTwoEnd", rangeTwoEnd)).
+		Where("created_at >= @startTime", sql.Named("startTime", rangeTwoStart)).
+		Where("created_at< @endTime", sql.Named("endTime", rangeTwoEnd)).
+		Scan(&result).Error
+
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	// Query is still valid when the named params are not replaced
+	// hence it'll result the empty result
+	// so check if the result is not 0 to assert this
+	if result.RangeOne == 0 || result.RangeTwo == 0 {
+		t.Errorf("Failed, query did not produce proper result")
+	}
+}
+
+func getDailyRange(curTime time.Time) (string, string) {
+	startTime := time.Date(
+		curTime.Year(),
+		curTime.Month(),
+		curTime.Day(),
+		0,
+		0,
+		0,
+		0,
+		curTime.Location())
+
+	return startTime.Format("2006-01-02 15:04:05"), startTime.Add(24 * time.Hour).Format("2006-01-02 15:04:05")
+}
+
+func getYearlyRange(curTime time.Time) (string, string) {
+	startTime := time.Date(
+		curTime.Year(),
+		1,
+		1,
+		0,
+		0,
+		0,
+		0,
+		curTime.Location())
+
+	nextMonth := startTime.Add(365 * 24 * time.Hour)
+
+	nextMonth = time.Date(
+		nextMonth.Year(),
+		1,
+		1,
+		0,
+		0,
+		0,
+		0,
+		nextMonth.Location())
+
+	return startTime.Format("2006-01-02 15:04:05"), nextMonth.Format("2006-01-02 15:04:05")
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-dialects=("sqlite" "mysql" "postgres" "sqlserver")
+# running only on mysql because of the query syntax used for the example
+dialects=( "mysql")
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then


### PR DESCRIPTION
## Explain your use case and expected results

Enable using named arguments in the `Select` while writing custom queries. Currently named arguments can be used in where condition extending the same feature to select will give better flexibility 
