### PR TITLE
Demonstate a ** pointer failing for FirstOrCreate

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -19,8 +21,10 @@ func TestGORM(t *testing.T) {
 	// A record is inserted, but the name is NULL
 	var createResult User
 	// A double pointer triggers this behavior
-	if err := DB.FirstOrCreate(&createResult, &user).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if result := DB.FirstOrCreate(&createResult, &user); result.Error != nil {
+		t.Errorf("Failed, got error: %v", result.Error)
+	} else {
+		fmt.Printf("Rows affected %d\n", result.RowsAffected)
 	}
 
 	fmt.Printf("Condition param user ID (expect 0/unchaged) %d\n", user.ID)
@@ -36,6 +40,29 @@ func TestGORM(t *testing.T) {
 		if findResult.ID != createResult.ID {
 			t.Fatalf("User from create and user from find to not match. Create ID %d, find ID %d", findResult.ID, createResult.ID)
 		}
+	}
+}
+
+func TestRecordViolatesConstraint(t *testing.T) {
+	type Constraint struct {
+		gorm.Model
+		Count int
+	}
+	DB.AutoMigrate(&Constraint{})
+	DB.Exec(`ALTER TABLE constraints ADD CONSTRAINT count_check CHECK (count > 0);`)
+
+	user := &Constraint{}
+	var createResult Constraint
+	// A double pointer triggers this behavior
+	if result := DB.FirstOrCreate(&createResult, &user); result.Error != nil {
+		// This should error but does not.
+		// If plain `Create` is used there's an error. If a single pointer with FirstOrCreate is used a panic occurs.
+		t.Errorf("Failed, got error: %v", result.Error)
+	} else if result.RowsAffected != 1 {
+		// No error so presumably created?
+		t.Fatalf("Expected a row to have been created")
+	} else {
+		fmt.Printf("Rows %d\n", result.RowsAffected)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,54 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	name := "unique-user" + time.Now().Format(time.RFC3339)
+	user := &User{Name: name}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	// Observed postgres SQL:
+	// INSERT INTO "users" ("created_at","updated_at","deleted_at","name","age","birthday","company_id","manager_id","active") VALUES ('2021-03-08 12:32:59.863','2021-03-08 12:32:59.863',NULL,'',0,NULL,NULL,NULL,false) RETURNING "id"
+	// A record is inserted, but the name is NULL
+	var createResult User
+	// A double pointer triggers this behavior
+	if err := DB.FirstOrCreate(&createResult, &user).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	fmt.Printf("Condition param user ID (expect 0/unchaged) %d\n", user.ID)
+	fmt.Printf("Result user ID %d\n", createResult.ID)
+
+	// If no error from Create and a positive ID, the record should have been created and we should be able to find it.
+	if createResult.ID > 0 {
+		var findResult User
+		if err := DB.Model(&User{}).Where("name = ?", name).Find(&findResult).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+
+		if findResult.ID != createResult.ID {
+			t.Fatalf("User from create and user from find to not match. Create ID %d, find ID %d", findResult.ID, createResult.ID)
+		}
+	}
+}
+
+func TestPlainCreate(t *testing.T) {
+	name := "create-user" + time.Now().Format(time.RFC3339)
+	user := &User{Name: name}
+
+	// Even with a double pointer this generates the record.
+	if err := DB.Create(&user).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	fmt.Printf("Result user ID %d\n", user.ID)
+
+	// If no error from Create and a positive ID, the record should have been created and we should be able to find it.
+	if user.ID > 0 {
+		var findResult User
+		if err := DB.Model(&User{}).Where("name = ?", name).Find(&findResult).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+
+		if findResult.ID != user.ID {
+			t.Fatalf("User from create and user from find to not match. Create ID %d, find ID %d", findResult.ID, user.ID)
+		}
 	}
 }


### PR DESCRIPTION
If the conditions/where param for FirstOrCreate is a double pointer
no record will be created. This is unexpected because:
* No error is returned
* The out paramater is populated as if the record was created
* Standard Create seems to allow the double pointer
* GORM V1 allowed the double pointer

## Explain your user case and expected results
