### PR TITLE
Invalid guess of relation with custom tag

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,136 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+type (
+	Customer struct {
+		gorm.Model
+		Name      string
+		ManagerID *uint
+		Manager   *Customer
 	}
+	CustomerWrapper struct {
+		Customer
+	}
+	Employee struct {
+		gorm.Model
+		Name       string
+		ManagerRef *uint
+		Manager    *Employee `gorm:"foreignKey:ManagerRef"`
+	}
+	EmployeeWrapper struct {
+		Employee
+	}
+)
+
+func (CustomerWrapper) TableName() string {
+	return "customer"
+}
+func (EmployeeWrapper) TableName() string {
+	return "employees"
+}
+
+func TestGORM(t *testing.T) {
+	err := DB.AutoMigrate(new(User), new(Employee))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if true {
+		manager := &Employee{
+			Name: "Boss",
+		}
+		DB.Create(manager)
+
+		/* schema/relationship.go:guessRelation(relation *Relationship, field *Field, cgl guessLevel)
+		if gl == guessGuess {
+			if field.Schema == relation.FieldSchema {
+				gl = guessBelongs <<
+			} else {
+				gl = guessHas
+			}
+		}
+		*/
+
+		user1 := &Employee{
+			Name:    "User1",
+			Manager: manager,
+		}
+		DB.Create(user1)
+
+		/* schema/relationship.go:guessRelation(relation *Relationship, field *Field, cgl guessLevel)
+		if gl == guessGuess {
+			if field.Schema == relation.FieldSchema {
+				gl = guessBelongs
+			} else {
+				gl = guessHas <<
+			}
+		}
+		*/
+
+		user2 := &Employee{
+			Name:    "User2",
+			Manager: manager,
+		}
+		DB.Create(&EmployeeWrapper{Employee: *user2})
+
+		var m Employee
+
+		DB.First(&m)
+
+		if m.ManagerRef != nil {
+			t.Fatal("manager must not have manager")
+		}
+	} else {
+		manager := &Customer{
+			Name: "boss",
+		}
+		DB.Create(manager)
+
+		/* schema/relationship.go:guessRelation(relation *Relationship, field *Field, cgl guessLevel)
+		if gl == guessGuess {
+			if field.Schema == relation.FieldSchema {
+				gl = guessBelongs <<
+			} else {
+				gl = guessHas
+			}
+		}
+		*/
+		user1 := &Customer{
+			Name:    "user1",
+			Manager: manager,
+		}
+		DB.Create(user1)
+
+		/* schema/relationship.go:guessRelation(relation *Relationship, field *Field, cgl guessLevel)
+		if gl == guessGuess {
+			if field.Schema == relation.FieldSchema {
+				gl = guessBelongs <<
+			} else {
+				gl = guessHas
+			}
+		}
+		*/
+		user2 := &Customer{
+			Name:    "user2",
+			Manager: manager,
+		}
+		DB.Create(&CustomerWrapper{Customer: *user2})
+
+		var m Customer
+
+		DB.First(&m)
+
+		if m.ManagerID != nil {
+			t.Fatal("manager must not have manager")
+		}
+	}
+
 }


### PR DESCRIPTION
## Invalid guess of relation

BelongsTo relation guess is incorrect when explicit `foreignKey` tag used and not the default  field name if embedded struct  used for reference. 

The sample code shows the working and the not working versions. 

Proposed fix could be something like this which assumes if the table is the same the schema is the same even though if the Struct is different 

[Difference between the two route when foreign key is explicit](https://github.com/go-gorm/gorm/blob/master/schema/relationship.go#L401)

[relationship.go](https://github.com/go-gorm/gorm/blob/master/schema/relationship.go#L357)

```golang
	if gl == guessGuess {
		if field.Schema == relation.FieldSchema || field.Schema.Table == relation.FieldSchema.Table {
			gl = guessBelongs
		} else {
			gl = guessHas
		}
	}
``` 