### PR TITLE
Seems not `Exec` supports dollar placeholder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,16 @@ module gorm.io/playground
 go 1.14
 
 require (
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/kr/pty v1.1.8 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 // indirect
 	gorm.io/driver/mysql v1.0.5
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.6
-	gorm.io/gorm v1.21.3
+	gorm.io/driver/sqlserver v1.0.7
+	gorm.io/gorm v1.21.4
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,10 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	tx := DB.Begin()
-	defer tx.Rollback()
-
-	if err := tx.Exec(
+	if err := DB.Exec(
 		`INSERT INTO "users" ( "id" ) VALUES ( $1 )`,
 		`1`,
 	).Error; err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,13 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	tx := DB.Begin()
+	defer tx.Rollback()
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err := tx.Exec(
+		`INSERT INTO "users" ( "id" ) VALUES ( $1 )`,
+		`1`,
+	).Error; err != nil {
+		t.Errorf("Failed, got error:%v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

### What did I do

* `GORM_DIALECT=postgres go test`
* Now I am migrating V1 to V2, this kind of execution was succeeded in V1. But seems not in V2.

### Expected

* Test passes

### Actual

* Test failed

```
% GORM_DIALECT=postgres go test
2021/04/20 21:07:51 testing postgres...

2021/04/20 21:07:51 /Users/noriki/tools/playground/main_test.go:12 ERROR: there is no parameter $1 (SQLSTATE 42P02)
[1.204ms] [rows:0] INSERT INTO "users" ( "id" ) VALUES ( $1$ )
--- FAIL: TestGORM (0.00s)
    main_test.go:16: Failed, got error:ERROR: there is no parameter $1 (SQLSTATE 42P02)
FAIL
exit status 1
FAIL    gorm.io/playground      0.385s
```
