### PR TITLE
Retrieving tx data on custom join table hook

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &UserLanguage{}}
+
+	// if I comment this line, it works (because the custom join table is not used)
+	DB.SetupJoinTable(&User{}, "Languages", &UserLanguage{})
+
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.14
 
 require (
-	gorm.io/driver/mysql v1.0.5
+	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.6
-	gorm.io/gorm v1.21.3
+	gorm.io/driver/sqlserver v1.0.7
+	gorm.io/gorm v1.21.9
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	//"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,25 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		Name: "jinzhu",
+		Languages: []Language{
+			Language{
+				Code: "EN",
+				Name: "English",
+			},
+		},
+	}
 
-	DB.Create(&user)
+	DB.Set("user", "gabriel").Create(&user)
+
+	// I also tried Scopes() but didn't work too
+	// DB.Scopes(func(db *gorm.DB) *gorm.DB {
+	//     return db.Set("user", "gabriel")
+	// }).Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Preload("Languages").First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -3,7 +3,7 @@ package main
 import (
 	"database/sql"
 	"time"
-
+	"fmt"
 	"gorm.io/gorm"
 )
 
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	CreatedBy string `gorm:"not null;default:null"`
 }
 
 type Account struct {
@@ -50,11 +51,35 @@ type Toy struct {
 }
 
 type Company struct {
+	gorm.Model
 	ID   int
 	Name string
 }
 
 type Language struct {
-	Code string `gorm:"primarykey"`
+	gorm.Model
+	Code string
 	Name string
+}
+
+type UserLanguage struct {
+	gorm.Model
+	UserID int
+	LanguageID int
+	CreatedBy string `gorm:"not null;default:null"`
+}
+
+func (ul *User) BeforeCreate(tx *gorm.DB) error {
+	if user, ok := tx.Get("user"); ok {
+		ul.CreatedBy = fmt.Sprintf("%v", user)
+	}
+	return nil
+}
+
+func (ul *UserLanguage) BeforeCreate(tx *gorm.DB) error {
+	// why I can't get "user" here?
+	if user, ok := tx.Get("user"); ok {
+		ul.CreatedBy = fmt.Sprintf("%v", user)
+	}
+	return nil
 }


### PR DESCRIPTION
## Explain your user case and expected results
I would like to add more columns to the JoinTables, such as CreatedAt and CreatedBy.
To do that, I am using `SetupJoinTable()` to create the JoinTable with a custom Model.
The columns values are set using hooks `BeforeCreate()` and `BeforeSave()`. For some values, I need to pass data via `DB.Set()` and retrieve it with `tx.Get()` inside the hook. This works of all cases, except for the JoinTable Model hooks.

What am I doing wrong?
