### PR TITLE
Update Model inside BeforeDelete hook

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,50 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// create some users
+	users := []User{
+		User{Name: "A", Age: 10},
+		User{Name: "B", Age: 18},
+		User{Name: "C", Age: 24},
+		User{Name: "D", Age: 32},
+	}
 
-	DB.Create(&user)
+	DB.Create(&users)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var results []User
+	if err := DB.Find(&results).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if len(users) != len(results) {
+		t.Errorf("Failed, expected to create %d users but only %d were created",
+			len(users), len(results))
+	}
+
+	for _, u := range results {
+		if u.DeletedBy != "" {
+			t.Errorf("Failed, DeletedBy should be empty for UserID %d", u.ID)
+		}
+	}
+
+	// delete some users
+	users = users[2:4]
+	if err := DB.Delete(&User{}, "age > 21").Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.Find(&results).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if len(users) != len(results) {
+		t.Errorf("Failed, expected to create %d users but only %d were created",
+			len(users), len(results))
+	}
+
+	for _, u := range results {
+		if u.DeletedBy != "gabriel" {
+			t.Errorf("Failed, DeletedBy should not be empty for UserID %d", u.ID)
+		}
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
I want to make some modifications to the Model inside the `BeforeDelete` hook. For example, to set the value of column `DeletedBy` and keep the normal behavior of `gorm` to update the `DeletedAt` (soft delete). However, I can't find a way to do this. I tried many approaches and combinations and tried to copy some code from `SoftDeleteDeleteClause.ModifyStatement()`, but nothing worked for me. 

I expect `BeforeDelete`  to behave similar to how `BeforeCreate` or `BeforeUpdate` works:
```go
func (u *User) BeforeDelete(tx *gorm.DB) error {
    u.DeletedBy = "gabriel" // Model should be updated here for all records in this transaction
    return nil
}
```