### PR TITLE
Why does gorm attempt to update an artist instead of insert it?

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.0
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/gorm v1.21.10
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -17,4 +21,41 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestShouldInsert(t *testing.T) {
+	if err := DB.AutoMigrate(Artist{}); err != nil {
+		t.Fatalf("error migrating releases table %s", err)
+	}
+
+	tx := DB.Begin().Debug()
+	defer tx.Rollback()
+
+	// The expected result is that an artist should be inserted, but for some
+	// reason gorm tries to update, which fails due to a lack of where-clause.
+	if err := doArtist(tx, "new artist name"); err != nil {
+		t.Fatalf("error %s", err)
+	}
+}
+
+func doArtist(tx *gorm.DB, name string) (err error) {
+	artist := &Artist{}
+	err = tx.Where(Artist{Name: name}).
+		Attrs(Artist{Name: name}).
+		FirstOrInit(&artist).Error
+	if err != nil {
+		return fmt.Errorf("initializing artist %s", err)
+	}
+	log.Printf("<<<<>>>> the new artist's id is %d <<<<>>>>", artist.ID)
+	err = tx.Save(&artist).Error
+	if err != nil {
+		return fmt.Errorf("saving artist %s", err)
+	}
+
+	return nil
+}
+
+type Artist struct {
+	gorm.Model
+	Name string
 }


### PR DESCRIPTION
## Explain your user case and expected results

I expect my test case to successfully perform an INSERT, because the `artist` instance has an `ID` of 0. What I observe is an UPDATE being performed, and failing due to a lack of WHERE clause.

I'm upgrading some code from v1.9.10 where this worked fine, but with v1.21.10 it fails.

Is there some configuration tweak I need to make?