### PR TITLE
OnConflict + Create doest not work with sqlite

### DIFF
--- a/db.go
+++ b/db.go
@@ -70,6 +70,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 	default:
 		log.Println("testing sqlite3...")
 		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {
@@ -83,7 +84,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &PackageName{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
@@ -105,4 +106,11 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+	DB.Exec(`
+CREATE TABLE IF NOT EXISTS package_names
+(
+    id   SERIAL PRIMARY KEY NOT NULL,
+    name TEXT UNIQUE        NOT NULL CHECK ( name <> '' )
+)
+`)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gorm.io/playground
 
-go 1.16
+go 1.15
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
@@ -17,4 +17,4 @@ require (
 	gorm.io/gorm v1.21.9
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/main.go
+++ b/main.go
@@ -1,7 +1,60 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"gorm.io/gorm/clause"
+)
+
+type Base struct {
+	ID int `gorm:"primaryKey;unique"`
+}
+type PackageName struct {
+	Base
+	Name string `gorm:"unique"`
+}
+
+var onConflict = clause.OnConflict{
+	Columns: []clause.Column{{Name: "name"}},
+	DoUpdates: []clause.Assignment{{
+		Column: clause.Column{Name: "name"},
+		Value:  clause.Column{Table: "excluded", Name: "name"},
+	}},
+}
 
 func main() {
-	fmt.Println("vim-go")
+	var written []PackageName
+	var read []PackageName
+
+	for i := 0; i < 10; i++ {
+		written = append(written, PackageName{Name: fmt.Sprintf("N%v", i+1)})
+	}
+	// Create items
+	DB.Clauses(onConflict).CreateInBatches(&written, 5)
+	fmt.Printf("Returned: \n")
+	for _, n := range written {
+		fmt.Printf("id:%d name:%v\n", n.ID, n.Name)
+	}
+
+	// Do something in the middle
+	DB.Create(&User{})
+
+	// Create a set of new items, partly overlapping
+	for i := 0; i < 10; i++ {
+		written[i].ID = 0
+		written[i].Name = fmt.Sprintf("N%d", 5+i)
+	}
+
+	// Write a second set of items
+	DB.Clauses(onConflict).CreateInBatches(&written, 5)
+	fmt.Printf("Returned second: \n")
+	for _, n := range written {
+		fmt.Printf("id:%d name:%v\n", n.ID, n.Name)
+	}
+
+	// Read back actual database state
+	DB.Find(&read)
+	fmt.Printf("Actual: \n")
+	for _, n := range read {
+		fmt.Printf("id:%d name:%v\n", n.ID, n.Name)
+	}
 }


### PR DESCRIPTION
When using OnConflict clause on SQLite, the Create method returns invalid primary keys

Output on my machine:
```

Returned: 
id:1 name:N1
id:2 name:N2
id:3 name:N3
id:4 name:N4
id:5 name:N5
id:6 name:N6
id:7 name:N7
id:8 name:N8
id:9 name:N9
id:10 name:N10

Returned second: 
id:-3 name:N5
id:-2 name:N6
id:-1 name:N7
id:0 name:N8
id:1 name:N9
id:10 name:N10
id:11 name:N11
id:12 name:N12
id:13 name:N13
id:14 name:N14

Actual: 
id:1 name:N1
id:2 name:N2
id:3 name:N3
id:4 name:N4
id:5 name:N5
id:6 name:N6
id:7 name:N7
id:8 name:N8
id:9 name:N9
id:10 name:N10
id:11 name:N11
id:12 name:N12
id:13 name:N13
id:14 name:N14
```

The `Returned Second` indicates that the updated objects have primary keys set to negative integers, which is nonsense. The created entries have correct primary key. The expectation is that the database returns preexisting primary key for updated objects.