### PR TITLE
`nil` error returned instead of record not found with `Raw()`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.0
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -14,7 +16,21 @@ func TestGORM(t *testing.T) {
 	DB.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+
+	// create the SQL query to display a bug
+	query := "SELECT * FROM users WHERE name = ?"
+
+	// run the good raw SQL query to display the query is valid
+	goodResult := DB.Raw(query, "jinzhu").Scan(&result)
+	// should return no error since user 'jinzhu' exists
+	if err := goodResult.Error; err != nil {
+		t.Errorf("Gorm Raw() Failed, got: %v, want: %v", err, nil)
+	}
+
+	// run the bad raw SQL query to display the bug
+	badResult := DB.Raw(query, "foobar").Scan(&result)
+	// should return gorm.ErrRecordNotFound since user 'foobar' does not exist
+	if err := badResult.Error; err == nil {
+		t.Errorf("Gorm Raw() Failed, got: %v, want: %v", err, gorm.ErrRecordNotFound)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func TestGORM(t *testing.T) {
 	var result User
 
 	// create the SQL query to display a bug
-	query := "SELECT * FROM users WHERE name = ?"
+	query := "SELECT * FROM users WHERE name = ?;"
 
 	// run the good raw SQL query to display the query is valid
 	goodResult := DB.Raw(query, "jinzhu").Scan(&result)


### PR DESCRIPTION
## Explain your user case and expected results

### What did I do

* ran `./test.sh` [based off the docs](https://github.com/go-gorm/playground#4-run-tests-with-lastest-gorm-and-all-drivers)
* migrating from V1 to V2 - GORM previously returned `record not found` when a query ran with no result

### Expected

* The tests should pass
* GORM should return `record not found` as a non-nil error (`gorm.ErrRecordNotFound`)

### Actual

```
$ ./test.sh
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
remote: Enumerating objects: 162, done.
remote: Counting objects: 100% (162/162), done.
remote: Compressing objects: 100% (156/156), done.
remote: Total 162 (delta 13), reused 43 (delta 2), pack-reused 0
Receiving objects: 100% (162/162), 167.89 KiB | 3.23 MiB/s, done.
Resolving deltas: 100% (13/13), done.
testing sqlite...
2021/05/26 15:27:01 testing sqlite3...
=== RUN   TestGORM

2021/05/26 15:27:01 /Users/jbrockopp/repos/github.com/jbrockopp/playground/main_test.go:16
[1.544ms] [rows:1] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`) VALUES ("2021-05-26 15:27:01.355","2021-05-26 15:27:01.355",NULL,"jinzhu",0,NULL,NULL,NULL,false)

2021/05/26 15:27:01 /Users/jbrockopp/repos/github.com/jbrockopp/playground/main_test.go:24
[0.436ms] [rows:1] SELECT * FROM users WHERE name = "jinzhu";

2021/05/26 15:27:01 /Users/jbrockopp/repos/github.com/jbrockopp/playground/main_test.go:31
[0.123ms] [rows:0] SELECT * FROM users WHERE name = "foobar";
    main_test.go:34: Gorm Raw() Failed, got: <nil>, want: record not found
--- FAIL: TestGORM (0.00s)
FAIL
FAIL	gorm.io/playground	0.861s
FAIL
```

### More Information

The query being ran is simple in nature:

```sql
SELECT *
FROM users
WHERE name = ?;
```

I've provided a sample where we run the query with an argument of `jinzhu` to demonstrate the query is valid.

I then provided a sample where we run the query with an argument of `foobar` to demonstrate the bug.

GORM should return `record not found` as a non-nil error (`gorm.ErrRecordNotFound`)