### PR TITLE
Scan sometimes logs an error but does not return it.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.0
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,30 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// When we mistakenly pass an entire struct, which has a map as one of its fields, as the Scan destination, Scan
+	// logs an error, but does not return it.
+	//
+	// [error] unsupported data type: &map[]
 
-	DB.Create(&user)
+	s := struct {
+		I int64
+		M map[string]string
+	}{}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	err := DB.Raw("SELECT 7").Scan(&s.I).Error
+	if err != nil {
+		t.Fatal("expected no error")
+	}
+	if s.I != 7 {
+		t.Fatalf("expected s.I to be 7, got %d", s.I)
+	}
+
+	// We mistakenly passed "&s" instead of "&s.I"
+	err = DB.Raw("SELECT 13").Scan(&s).Error
+	if err == nil {
+		t.Error("expected an error, got nil")
+	}
+	if s.I != 7 {
+		t.Errorf("expected s.I to be 7, got %d", s.I)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
When we mistakenly pass an entire struct, which has a map as one of its fields, as the `Scan` destination, `Scan` logs an error, but does not return it.

```
[error] unsupported data type: &map[]
```