### PR TITLE
add test to show need for additional DeleteInBatch()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -9,12 +12,29 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	type TestItem struct {
+		gorm.Model
+		Data string
 	}
+
+	err := DB.AutoMigrate(TestItem{})
+	assert.Nil(t, err)
+
+	err = DB.Unscoped().Delete(TestItem{}).Error
+	assert.Nil(t, err)
+
+	size := 70000 // Max is 65536 placeholders
+	items := make([]TestItem, 0, size)
+	for idx := 0; idx < size; idx++ {
+		items = append(items, TestItem{
+			Model: gorm.Model{ID: uint(idx + 1)}, Data: fmt.Sprintf("Data_%d", idx),
+		})
+	}
+
+	err = DB.CreateInBatches(items, 13000).Error
+	assert.Nil(t, err)
+
+	// Throws error, maybe good idea to have DeleteInBatch(value interface{}, batchSize int) similar to CreateInBatch
+	err = DB.Unscoped().Delete(items).Error
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Change-Id: I2d4ab840d397a4ffb317c21417c4865ef58decd4

## Explain your user case and expected results
**Expected:** Delete > 65536 items from DB without error

**Actual:** Delete > 65536 items from DB has error due to "too many SQL variables".

Tested on GORM v1.21.9. I think this can be very similar to `CreateInBatch` function that gorms already offers.

Thanks and sorry if this was already mentioned! :)
