### PR TITLE
nil rows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,14 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/gorm v1.21.11
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -16,5 +18,13 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	var maxId int64
+	userTable := func(db *gorm.DB) *gorm.DB {
+		return db.WithContext(context.Background()).Table("users")
+	}
+	if err := DB.Scopes(userTable).Select("max(id)").Scan(&maxId).Error; err != nil {
+		t.Errorf("select max(id)")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

Test will panic during the scan at https://github.com/go-gorm/gorm/blob/master/finisher_api.go#L457-L461.

```
goroutine 18 [running]:
testing.tRunner.func1.2(0x46b3b00, 0x4b4f930)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc00008a480)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0x46b3b00, 0x4b4f930)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/database/sql/sql.go:3165 +0x76
database/sql.(*Rows).Close(0x0, 0x8, 0xc0000b2190)
	/usr/local/go/src/database/sql/sql.go:3161 +0x33
panic(0x46b3b00, 0x4b4f930)
	/usr/local/go/src/runtime/panic.go:971 +0x499
database/sql.(*Rows).Next(0x0, 0x0)
	/usr/local/go/src/database/sql/sql.go:2842 +0x30
gorm.io/gorm.(*DB).Scan(0xc00009f860, 0x4684400, 0xc0000a6c00, 0x0)
	/Users/zee/code/go/pkg/mod/gorm.io/gorm@v1.21.11/finisher_api.go:461 +0x3c6
gorm.io/playground.TestGORM(0xc00008a480)
	/Users/zee/code/go/src/github.com/go-gorm/playground/main_test.go:27 +0x32c
testing.tRunner(0xc00008a480, 0x47598e0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3
```