### PR TITLE
error on count when order is included on postgres

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
+	github.com/jackc/pgproto3/v2 v2.1.0 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.1
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/gorm v1.21.11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +15,15 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var (
+		count int64
+		query = DB.Model(&User{}).Order("users.id ASC")
+		session = query.Session(&gorm.Session{})
+	)
+	if err := query.Count(&count).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if err := session.Count(&count).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
Postgres errors when a  `db.Count()` is called on a query that has an `Order()`, but only if the instance we're calling `Count()` is a clone created by calling `Session()`.

All databases produce the same queries but only Postgres errors. My expectation is really that the query produced by `Count()` should be the same irrespective of the call to `Session()`.

Query generated on original instance:
```
 SELECT count(*) FROM `users` WHERE `users`.`deleted_at` IS NULL
```

Query generated on `Session()` cloned instance:
```
SELECT count(*) FROM `users` WHERE `users`.`deleted_at` IS NULL ORDER BY users.id ASC
```

Not that it should matter, but you can flip around the order in which the queries are called and it's consistent. The instance cloned with `Session()` always adds the `ORDER BY` clause to the count query.