### PR TITLE
incorrect where clause generated from model query of the joined table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
+	github.com/jackc/pgproto3/v2 v2.1.0 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.1
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/gorm v1.21.11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,46 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// create 2 users, each with an one-2-many relationship
+	user1 := User{Name: "Alice", Age: 34, Active: true,
+		Pets: []*Pet{
+			{Name: "Doggo"},
+			{Name: "Pepe the frog"},
+		}}
+	user2 := User{Name: "Bob", Age: 35, Active: false, Pets: []*Pet{
+		{Name: "Nyan cat"},
+	}}
 
-	DB.Create(&user)
+	if err := DB.Create(&user1).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if err := DB.Create(&user2).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	// looking for a pet name 'Doggo'
+	tx := DB.Where(Pet{Name: "Doggo"})
+
+	//
+	// SQL generated:
+	// SELECT `pets`.`id`,`pets`.`created_at`,`pets`.`updated_at`,`pets`.`deleted_at`,`pets`.`user_id`,`pets`.`name` FROM `pets` JOIN users u on u.id = pets.user_id WHERE `pets`.`name` = "Doggo" AND u.name = "Alice" AND `pets`.`deleted_at` IS NULL ORDER BY `pets`.`id` LIMIT 1
+	//
+	// uncomment this and the test will pass:
+	//
+	// tx = tx.Joins("JOIN users u on u.id = pets.user_id").Where("u.name = ?", "Alice")
+	//
+
+	//
+	// SQL generated:
+	// SELECT `pets`.`id`,`pets`.`created_at`,`pets`.`updated_at`,`pets`.`deleted_at`,`pets`.`user_id`,`pets`.`name` FROM `pets` JOIN users u on u.id = pets.user_id WHERE `pets`.`name` = "Doggo" AND `pets`.`name` = "Alice" AND `pets`.`deleted_at` IS NULL ORDER BY `pets`.`id` LIMIT 1
+	//
+	// uncomment this and the test will fail:
+	//
+	tx = tx.Joins("JOIN users u on u.id = pets.user_id").Where(&User{Name: "Alice"})
+	//
+
+	pet := Pet{}
+	if err := tx.First(&pet).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
gorm will incorrectly generate the where clause to be against the current table (~~~ct~~~) instead of taking it from the model's type.
![Screenshot 2021-07-01 at 11 40 47](https://user-images.githubusercontent.com/1477846/124105242-548bd600-da63-11eb-871e-4eeaa0a161a8.png)

in such cases currently, it can only be worked around by specifying the where clause explicitly as string.

## Explain your user case and expected results
