### PR TITLE
ON DELETE CASCADE fails on composite foreign keys

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Employment{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
+	github.com/jackc/pgproto3/v2 v2.1.0 // indirect
 	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.1
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/gorm v1.21.11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -6,15 +6,48 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TE-ST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	err := DB.Create(&user).Error
+	assertNoError(t, err)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	company := Company{Name: "jinzhu corp"}
+
+	err = DB.Create(&company).Error
+	assertNoError(t, err)
+
+	employment := Employment{
+		Company: company,
+		User:    user,
+	}
+	err = DB.Create(&employment).Error
+	assertNoError(t, err)
+
+	// delete should cascade and delete employment automatically
+	err = DB.Delete(&User{}, user.ID).Error
+	assertNoError(t, err)
+
+	var count int64
+
+	err = DB.Model(&User{}).Count(&count).Error
+	assertNoError(t, err)
+	if count != 0 {
+		t.Errorf("Unexpected user count: %d", count)
+	}
+
+	err = DB.Model(&Employment{}).Count(&count).Error
+	assertNoError(t, err)
+	if count != 0 {
+		t.Errorf("Unexpected employment count: %d", count)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -13,20 +13,21 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	Name        string
+	Age         uint
+	Birthday    *time.Time
+	Account     Account
+	Pets        []*Pet
+	Toys        []Toy `gorm:"polymorphic:Owner"`
+	CompanyID   *int
+	Company     Company
+	ManagerID   *uint
+	Manager     *User
+	Team        []User     `gorm:"foreignkey:ManagerID"`
+	Languages   []Language `gorm:"many2many:UserSpeak"`
+	Friends     []*User    `gorm:"many2many:user_friends"`
+	Active      bool
+	Employments []Employment
 }
 
 type Account struct {
@@ -57,4 +58,11 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+type Employment struct {
+	CompanyID uint    `gorm:"primaryKey"`
+	UserID    uint    `gorm:"primaryKey;index"`
+	Company   Company `gorm:"constraint:OnDelete:CASCADE;"`
+	User      User    `gorm:"constraint:OnDelete:CASCADE;"`
 }


### PR DESCRIPTION
## Explain your user case and expected results
Added  a new table:
```
type Employment struct {
	CompanyID uint    `gorm:"primaryKey"`
	UserID    uint    `gorm:"primaryKey;index"`
	Company   Company `gorm:"constraint:OnDelete:CASCADE;"`
	User      User    `gorm:"constraint:OnDelete:CASCADE;"`
}
```
Expected that deleting a user would cascade and delete any employments, but this doesn't happen. No ON DELETE CASCADE constraint is created for composite foreign keys.