### PR TITLE
Bug in COUNT(DISTINCT(table.*))

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -10,11 +10,24 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
+	pet := Pet{UserID: &user.ID, Name: "jinzhu"}
 
 	DB.Create(&user)
+	DB.Create(&pet)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	// This is fine
+	if err := DB.Model(&User{}).Distinct("users.*").Joins("JOIN pets ON users.id = pets.user_id").Find(&user).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// This is also fine
+	var count int64
+	if err := DB.Model(&User{}).Distinct("users.id").Joins("JOIN pets ON users.id = pets.user_id").Count(&count).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// This is not
+	if err := DB.Model(&User{}).Distinct("users.*").Joins("JOIN pets ON users.id = pets.user_id").Count(&count).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When trying to generate statements of the form:

```sql
SELECT COUNT(DISTINCT(table.*))
```

The following is generated instead:
```sql
SELECT COUNT(DISTINCT(`table`.`*`))
```

