### PR TITLE
test: infinites

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -9,12 +10,23 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	positiveInf, _ := strconv.ParseFloat("+Inf", 64)
+	negativeInf, _ := strconv.ParseFloat("-Inf", 64)
 
-	DB.Create(&user)
+	testCases := []User{
+		{Point: 0.0},         // Will pass
+		{Point: positiveInf}, // Fail
+		{Point: negativeInf}, // Fail
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	for _, tc := range testCases {
+		if err := DB.Create(&tc).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+
+		var result User
+		if err := DB.First(&result, tc.ID).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
 	}
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Point     float64
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

Infinites numbers to be handled well. Golang use +Inf and -Inf to represent infinites, some databases handle this values well like SQLite, but others one use the word "infinite" so when a infinite float appear on SQL Query it breaks.

Not working: 

- Postgres 
- MySQL
- SQLServer
