### PR TITLE
add failing gorm test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
+	github.com/google/uuid v1.3.0
+	github.com/jackc/pgx/v4 v4.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.8 // indirect
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.1
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,15 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	u := &User{Name: "george"}
+	DB.Create(&u)
 
-	DB.Create(&user)
+	DB.Create(&User{Name: "jinzhu", Friends: []*User{u}})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	george := &User{}
+	DB.Model(&User{}).Where("name = ?", "george").Find(george)
+	if err := george.UUID.String() != u.UUID.String(); err {
+		t.Error("Failed, u.UUID has changed but the the one in the DB is the same")
 	}
+
 }

--- a/models.go
+++ b/models.go
@@ -5,7 +5,18 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"github.com/google/uuid"
 )
+
+type ID struct {
+	UUID uuid.UUID
+}
+
+func (id  *ID) BeforeCreate(tx *gorm.DB) error {
+	u := uuid.New()
+	tx.Statement.SetColumn("UUID", u)
+	return nil
+}
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
@@ -13,6 +24,7 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
+	ID
 	Name      string
 	Age       uint
 	Birthday  *time.Time


### PR DESCRIPTION
`BeforeCreate` method is called even when we won't create the passed object. That seems wrong because if we mutate the object in `BeforeCreate`, we are going to mutate our passed object with a value that differs from the one in the DB.