### PR TITLE
postgres bug: returning does not preserve insertion order thus being undeterministic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,16 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	github.com/jackc/pgx/v4 v4.13.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.8 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gorm.io/driver/mysql v1.1.2
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/sqlserver v1.0.8
+	gorm.io/gorm v1.21.13
+	gorm.io/datatypes v1.0.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -10,8 +11,13 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
+	// expect that it keeps the exact insertion fields order in RETURNING clause
+	returningPart := `RETURNING "id","address"`
+	tx := DB.Create(&user)
+	t.Errorf(tx.Statement.SQL.String())
+	if !strings.Contains(tx.Statement.SQL.String(), returningPart) {
+		t.Errorf("Expected fields in RETURNING clause preserve insertion order")
+	}
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -13,8 +14,9 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
+	Name      string         `gorm:"default:'John'"`
+	Age       uint           `gorm:"default:20"`
+	Address   datatypes.JSON `gorm:"default:'{\"address\":{\"city\":\"Madrid\",\"street\":\"Rojas\"}}'" sql:"type:jsonb"`
 	Birthday  *time.Time
 	Account   Account
 	Pets      []*Pet

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-dialects=("sqlite" "mysql" "postgres" "sqlserver")
+dialects=("postgres")
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then


### PR DESCRIPTION
## Explain your user case and expected results

Use case:
- using postgres DB and gorm
- set default jsonb value on one of model fields
- strict checking queries and responses - using `sqlmock` to check that given query produces given results (checking exact query with RETURNING part)

Problem:
https://github.com/go-gorm/gorm/blob/master/callbacks/create.go#L134 <- this iterates over the map, in such case, order is not guaranteed, thus leading to non deterministic behaviour of RETURNING clause. In my repo here, run tests a few times and check that insert statement returns random RETURNING fields list. Once it's `"id","address"`, next time it's `"address","id"`

Solution idea:
Preserve insertion order for default columns and avoid range over golang map (as it's order is non deterministic).

I would expect that this query always provides `RETURNING "id","address"` part, never the opposite way around.