### PR TITLE
Added failing validation for unnecessary schema migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,16 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/jackc/pgx/v4 v4.13.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.8 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	gorm.io/driver/mysql v1.1.2
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/sqlserver v1.0.8
+	gorm.io/gorm v1.21.13
 )
 
 replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -47,6 +47,7 @@ type Toy struct {
 	Name      string
 	OwnerID   string
 	OwnerType string
+	Cost      float32 `gorm:"type:float8"`
 }
 
 type Company struct {

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,11 @@ for dialect in "${dialects[@]}" ; do
     if [[ $(grep TEST_DRIVER main_test.go) =~ "${dialect}" ]]
     then
       echo "testing ${dialect}..."
-      GORM_DIALECT=${dialect} go test -race -count=1 -v ./...
+      GORM_DIALECT=${dialect} go test -race -count=1 -v ./... | tee ${EXPECT_MIGRATE}
+      if GORM_MIGRATE_NO_DROP_TABLES=1 GORM_DIALECT=${dialect} go test -race -count=1 -v ./... | grep -q "ALTER TABLE \"toys\" ALTER COLUMN \"cost\" TYPE float8"; then
+        echo "Schema migration executed twice against float8 column"
+        exit 1
+      fi
     else
       echo "skip ${dialect}..."
     fi


### PR DESCRIPTION
## Explain your user case and expected results
The `float8` column I added in this PR shouldn't be altered after the migration is run a second time, but it is (for postgres at least). See https://github.com/go-gorm/gorm/issues/4641