### PR TITLE
use datatypes.JSONMap with mysql: record not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
+	github.com/jackc/pgx/v4 v4.13.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.8 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gorm.io/datatypes v1.0.1
+	gorm.io/driver/mysql v1.1.2
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/sqlserver v1.0.8
+	gorm.io/gorm v1.21.14
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -7,14 +7,20 @@ import (
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
-
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	tag := map[string]interface{}{}
+	tag["int_array"] = []int{1, 2, 3}
+	tag["bool"] = false
+	user := User{Name: "jinzhu", Tag: tag}
 
 	DB.Create(&user)
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.Where(&result).Take(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"database/sql"
-	"time"
 
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"time"
 )
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
@@ -27,6 +28,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Tag       datatypes.JSONMap          `gorm:"column:tag"`
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

```
[8.618ms] [rows:1] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`,`tag`) VALUES ('2021-08-27 19:48:50.144','2021-08-27 19:48:50.144',NULL,'jinzhu',0,NULL,NULL,NULL,false,'{"bool":false,"int_array":[1,2,3]}')

2021/08/27 19:48:50 /Users/slyao/src/playground/main_test.go:19
[2.671ms] [rows:1] SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1

2021/08/27 19:48:50 /Users/slyao/src/playground/main_test.go:23 record not found
[3.013ms] [rows:0] SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`created_at` = '2021-08-27 19:48:50.144' AND `users`.`updated_at` = '2021-08-27 19:48:50.144' AND `users`.`name` = 'jinzhu' AND `users`.`tag` = '{"bool":false,"int_array":[1,2,3]}' AND `users`.`deleted_at` IS NULL AND `users`.`id` = 1 LIMIT 1
    main_test.go:24: Failed, got error: record not found
```

sql of `DB.Where(&result).Take(&result)` is below. But it  got `record not found`
```
SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`created_at` = '2021-08-27 19:48:50.144' AND `users`.`updated_at` = '2021-08-27 19:48:50.144' AND `users`.`name` = 'jinzhu' AND `users`.`tag` = '{"bool":false,"int_array":[1,2,3]}' AND `users`.`deleted_at` IS NULL AND `users`.`id` = 1 LIMIT 1`
```

### Expected

for mysql, `datatypes.JSONMap` can work well