### PR TITLE
Saving a model with a datatypes.JSON member: WHERE conditions required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/denisenkom/go-mssqldb v0.11.0 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/datatypes v1.0.2
+	gorm.io/driver/mysql v1.1.2
+	gorm.io/driver/postgres v1.1.1
+	gorm.io/driver/sqlite v1.1.5
+	gorm.io/driver/sqlserver v1.0.9
+	gorm.io/gorm v1.21.15
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,12 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestSaveJSON(t *testing.T) {
+	thing := ThingWithJSON{Data: nil}
+
+	err := DB.Save(&thing).Error
+	if err != nil {
+		t.Errorf("Failed to save thing with json, got error: %w", err)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/datatypes"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -19,8 +21,17 @@ func TestGORM(t *testing.T) {
 	}
 }
 
-func TestSaveJSON(t *testing.T) {
+func TestSaveJSONNil(t *testing.T) {
 	thing := ThingWithJSON{Data: nil}
+
+	err := DB.Save(&thing).Error
+	if err != nil {
+		t.Errorf("Failed to save thing with json, got error: %w", err)
+	}
+}
+
+func TestSaveJSON(t *testing.T) {
+	thing := ThingWithJSON{Data: datatypes.JSON(`{"foo": "bar"}`)}
 
 	err := DB.Save(&thing).Error
 	if err != nil {

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -57,4 +58,8 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+type ThingWithJSON struct {
+	Data datatypes.JSON
 }


### PR DESCRIPTION
## Explain your user case and expected results

I have a model using the [datatypes.JSON custom type](https://github.com/go-gorm/datatypes). Attempting to call `.Save` on a model with it results in the error: "WHERE conditions required". I don't understand why - maybe I am not understanding how JSON is implemented under the hood and it needs special treatment?