### PR TITLE
WHERE conditions required, if primary key is not Updatable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,9 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	tx := DB.Save(&result)
+	if tx.Error != nil {
+		t.Errorf("Failed, got error: %v", tx.Error)
+	}
 }

--- a/models.go
+++ b/models.go
@@ -13,6 +13,7 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
+	ID        uint `gorm:"primaryKey;<-:create"`
 	Name      string
 	Age       uint
 	Birthday  *time.Time


### PR DESCRIPTION
If model primary key can be updated only on create (<-:create) and a pointer to a model is passed (DB.Save(&result))  this will result in a "WHERE conditions required" error