### PR TITLE
test(updates): can not preload associations on updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
+	github.com/google/go-cmp v0.3.1
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/driver/sqlserver v1.0.7
 	gorm.io/gorm v1.21.9
+	gotest.tools v2.2.0+incompatible
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,82 @@ package main
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gotest.tools/assert"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+func TestCreateUserWithNestedAssociations(t *testing.T) {
+	user := User{
+		Name: "jinzhu",
+		Friends: []*User{
+			{
+				Name: "gorm",
+				Languages: []Language{
+					{
+						Code: "EN",
+						Name: "English",
+					},
+				},
+			},
+		},
+	}
 
 	DB.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.Preload("Friends.Languages").First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	assert.DeepEqual(t, result, user, cmpopts.IgnoreFields(User{}, "Model"))
+}
+
+func TestUpdateUserWithNestedAssociations(t *testing.T) {
+	user := User{
+		Name: "john",
+		Friends: []*User{
+			{
+				Name: "doe",
+				Languages: []Language{
+					{
+						Code: "EN",
+						Name: "English",
+					},
+				},
+			},
+		},
+	}
+
+	DB.Create(&user)
+
+	var result User
+	if err := DB.Preload("Friends.Languages").First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	assert.DeepEqual(t, result, user, cmpopts.IgnoreFields(User{}, "Model"))
+
+	user.Friends = []*User{
+		{
+			Name: "paul",
+			Languages: []Language{
+				{
+					Code: "FR",
+					Name: "French",
+				},
+			},
+		},
+	}
+
+	var updated User
+	if err := DB.Preload("Friends.Languages").Updates(user).Scan(&updated).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	assert.DeepEqual(t, updated, user, cmpopts.IgnoreFields(User{}, "Model"))
 }

--- a/models.go
+++ b/models.go
@@ -24,8 +24,8 @@ type User struct {
 	ManagerID *uint
 	Manager   *User
 	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
+	Languages []Language `gorm:"many2many:UserSpeak;<-"`
+	Friends   []*User    `gorm:"many2many:user_friends;<-"`
 	Active    bool
 }
 


### PR DESCRIPTION
## Explain your user case and expected results

Preloading associations when updating a record does not seem to work. When comparing the updated row to the update with `assert.DeepEqual(t, updated, user, cmpopts.IgnoreFields(User{}, "Model"))`, we get the following error:

```go
--- FAIL: TestUpdateUserWithNestedAssociations (0.28s)
    main_test.go:82: assertion failed:
        --- updated
        +++ user
          main.User{
                ... // 1 ignored and 10 identical fields
                Team:      nil,
                Languages: nil,
        -       Friends:   nil,
        +       Friends: []*main.User{
        +               &{
        +                       Model: gorm.Model{
        +                               ID:        0x05,
        +                               CreatedAt: s"2021-09-29 10:01:45.457714 +0200 CEST",
        +                               UpdatedAt: s"2021-09-29 10:01:45.457714 +0200 CEST",
        +                       },
        +                       Name:      "paul",
        +                       Languages: []main.Language{{Code: "FR", Name: "French"}},
        +               },
        +       },
                Active: false,
          }


```

This shows us that the associations are actually not being preloaded if I'm right.