### PR TITLE
Add example of .Count breaking a query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4

--- a/main_test.go
+++ b/main_test.go
@@ -24,14 +24,12 @@ func TestGORM(t *testing.T) {
 	var total int64
 	query.Count(&total)
 
-	var result User
+	var result []User
 
-	// Incorrectly generates a 'SELECT *' query which causes companies.id to overwrite users.id
-	if err := query.First(&result, user.ID).Error; err != nil {
+	if err := query.Find(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
-
-	if result.ID != user.ID {
-		t.Errorf("result's id, %d, doesn't match user's id, %d", result.ID, user.ID)
+	if result[0].Company.ID == 0 {
+		t.Errorf("Failed, expected Company to be preloaded")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

My use case is calling `.Count` on gorm queries that use .Joins preloading. This worked in gorm v1.20.12. 