### PR TITLE
reproduce error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,14 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/denisenkom/go-mssqldb v0.11.0 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.2
+	gorm.io/driver/postgres v1.1.2
+	gorm.io/driver/sqlite v1.1.5
+	gorm.io/driver/sqlserver v1.0.9
+	gorm.io/gorm v1.21.15
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,47 @@
 package main
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type NewUser struct {
+	gorm.Model
+	Name  string `gorm:"index"`
+	City  string `gorm:"index"`
+	Table string `gorm:"-"`
+}
+
+/*
+NOTE: https://gorm.io/docs/v2_release_note.html#Breaking-Changes
+*/
+func UserTable(u *NewUser) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Table(fmt.Sprintf("newuser_%s", strings.ToLower(u.Table)))
+	}
+}
+
+// TableName which is cached
+func (u *NewUser) TableName() string {
+	return fmt.Sprintf("newuser_%s", u.Table)
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	tableName := []string{"a", "b", "c"}
+	for _, v := range tableName {
+		nu := &NewUser{
+			Table: v,
+		}
+		DB.Scopes(UserTable(nu)).Migrator().AutoMigrate(&nu)
+		if err := DB.Scopes(UserTable(nu)).Migrator().AutoMigrate(&nu); err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
I am trying to migrate tables using dynamic table name. The tables are created with the dynamic table name but the indexes are not created.
tableNameFormat  = 'newuser_%x'
table created successfully `newuser_a`, `newuser_b`,`newuser_c`

Error: Indexes are being created for the table `newuser_a` as `idx_newuser__deleted_at` which should be `idx_newuser_a_deleted_at`
