### PR TITLE
Empty time is not maintained

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,14 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.2
+	gorm.io/driver/postgres v1.1.2
+	gorm.io/driver/sqlite v1.1.6
+	gorm.io/driver/sqlserver v1.1.0
+	gorm.io/gorm v1.21.16
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,8 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	if result.TestedAt != user.TestedAt {
+		t.Errorf("Empty time is not maintained. Actual time: %v", result.TestedAt)
+	}
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	TestedAt  time.Time
 }
 
 type Account struct {


### PR DESCRIPTION
When we insert a row with an empty time, we'd expect to receive it back but right now it's populated with a timezone.
Failing message:
```
 [2.515ms] [rows:1] SELECT * FROM "users" WHERE "users"."id" = 1 AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1
    main_test.go:22: Empty time is not maintained. Actual time: 0000-12-31 20:53:32 -0306 LMT
--- FAIL: TestGORM (0.01s)
```