### PR TITLE
BUG:  column reference is ambiguous when use gorm.Expr of OnConflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: '3'
 
 services:
-  mysql:
-    image: 'mysql:latest'
-    ports:
-      - 9910:3306
-    environment:
-      - MYSQL_DATABASE=gorm
-      - MYSQL_USER=gorm
-      - MYSQL_PASSWORD=gorm
-      - MYSQL_RANDOM_ROOT_PASSWORD="yes"
   postgres:
     image: 'postgres:latest'
     ports:
@@ -19,14 +10,3 @@ services:
       - POSTGRES_DB=gorm
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
-  mssql:
-    image: 'mcmoe/mssqldocker:latest'
-    ports:
-      - 9930:1433
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=LoremIpsum86
-      - MSSQL_DB=gorm
-      - MSSQL_USER=gorm
-      - MSSQL_PASSWORD=LoremIpsum86
-

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,13 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.3
+	gorm.io/driver/postgres v1.2.1
+	gorm.io/driver/sqlite v1.2.3
+	gorm.io/driver/sqlserver v1.1.2
+	gorm.io/gorm v1.22.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"strconv"
 	"testing"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +21,90 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+type Detail struct {
+	gorm.Model
+	OrgID      string `gorm:"index;comment:组织id"`
+	OrderID    string `gorm:"unique;index;uniqueIndex;comment:订单id"`
+	PID        string `gorm:"index;comment:产品id"`
+	Apply      int    `gorm:"comment:申请"`
+	CreditSucc int    `gorm:"comment:审批"`
+	CreditFail int    `gorm:"comment:审批"`
+	Curr       int    `gorm:"comment:授信"`
+	Extract    int    `gorm:"comment:提款"`
+}
+
+func ds() int {
+	t := time.Now()
+	return int(time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location()).Unix())
+}
+
+func (d *Detail) AfterCreate(tx *gorm.DB) error {
+	t := ds()
+	s := Stat{
+		Time:       t,
+		OrgID:      d.OrgID,
+		PID:        d.PID,
+		Work:       d.CreditSucc + d.CreditFail,
+		Apply:      d.Apply,
+		CreditSucc: d.CreditSucc,
+		CreditFail: d.CreditFail,
+		Curr:       d.Curr,
+		Extract:    d.Extract,
+	}
+	sm := map[string]interface{}{
+		"work":        gorm.Expr("work + ?", s.Work),
+		"apply":       gorm.Expr("apply+?", s.Apply),
+		"credit_succ": gorm.Expr("credit_succ+?", s.CreditSucc),
+		"credit_fail": gorm.Expr("credit_fail + ?", s.CreditFail),
+		"curr":        gorm.Expr("curr + ?", s.Curr),
+		"extract":     gorm.Expr("extract + ?", s.Extract),
+	}
+
+	if err := tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "time"}, {Name: "org_id"}, {Name: "p_id"}},
+		DoUpdates: clause.Assignments(sm),
+	}).Create(&s).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type Stat struct {
+	gorm.Model
+	Time       int    `gorm:"index;comment:时间" pg:"unique:s"`
+	OrgID      string `gorm:"index;comment:组织id" pg:"unique:s"`
+	PID        string `gorm:"index;comment:产品id" pg:"unique:s"`
+	Apply      int    `gorm:"comment:申请"`
+	Work       int    `gorm:"comment:处理"`
+	CreditSucc int    `gorm:"comment:审批"`
+	CreditFail int    `gorm:"comment:审批"`
+	Curr       int    `gorm:"comment:授信"`
+	Extract    int    `gorm:"comment:提款"`
+}
+
+func TestGORM2(t *testing.T) {
+	if err := DB.AutoMigrate(new(Detail), new(Stat)); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if !DB.Migrator().HasIndex(new(Stat), "stats_a") {
+		if err := DB.Exec("CREATE UNIQUE INDEX stats_a on stats (time,org_id,p_id)").Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+	}
+	if err := DB.Create(&Detail{
+		OrgID:      "a",
+		PID:        "b",
+		OrderID:    strconv.Itoa(int(time.Now().UnixNano())),
+		Apply:      1,
+		CreditSucc: 0,
+		CreditFail: 0,
+		Curr:       0,
+		Extract:    0,
+	}).Error; err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
在`psql`里用多个字段约束进行`upsert`。
问题一：无法有效的绑定多个字段为约束
问题二：使用`gorm.Expr`进行增量更新时，出现字段无效

Use multiple field constraints for `upsert` in `psql`.
Problem 1: Cannot effectively bind multiple fields as constraints
Problem 2: When using `gorm.Expr` for incremental update, the field is invalid