### PR TITLE
Unscoped preload all not working

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,13 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.3
+	gorm.io/driver/postgres v1.2.1
+	gorm.io/driver/sqlite v1.2.3
+	gorm.io/driver/sqlserver v1.2.0
+	gorm.io/gorm v1.22.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,63 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		Name: "jinzhu",
+		Company: Company{
+			Name: "acme",
+		},
+		Manager: &User{
+			Name: "joe",
+		},
+	}
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	unscopedPreload := func(db *gorm.DB) *gorm.DB {
+		return db.Unscoped()
 	}
+
+	// soft delete company and manager
+	if result := DB.Where("name = ?", "acme").Delete(&Company{}); result.Error != nil {
+		t.Errorf("Error when deleting Company: %v", result.Error)
+	}
+
+	if result := DB.Where("name = ?", "joe").Delete(&User{}); result.Error != nil {
+		t.Errorf("Error when deleting User: %v", result.Error)
+	}
+
+	// This test succeeded as expected
+	t.Run("Distinct preloads", func(t *testing.T) {
+		var u User
+		if result := DB.Preload("Company", unscopedPreload).
+			Preload("Manager", unscopedPreload).
+			Find(&u, user.ID); result.Error != nil {
+			t.Errorf("Find failed: %v", result.Error)
+		}
+		if u.Company.Name != "acme" {
+			t.Errorf("Wrong company name")
+		}
+		if u.Manager == nil {
+			t.Errorf("Wrong manager")
+		} else if u.Manager.Name != "joe" {
+			t.Errorf("Wrong manager name")
+		}
+	})
+
+	// This test fails, which is unexpected
+	t.Run("Preload all", func(t *testing.T) {
+		var u User
+		if result := DB.Preload(clause.Associations, unscopedPreload).
+			Find(&u, user.ID); result.Error != nil {
+			t.Errorf("Find failed: %v", result.Error)
+		}
+		if u.Company.Name != "acme" {
+			t.Errorf("Wrong company name")
+		}
+		if u.Manager == nil {
+			t.Errorf("Wrong manager")
+		} else if u.Manager.Name != "joe" {
+			t.Errorf("Wrong manager name")
+		}
+	})
 }

--- a/models.go
+++ b/models.go
@@ -50,7 +50,7 @@ type Toy struct {
 }
 
 type Company struct {
-	ID   int
+	gorm.Model
 	Name string
 }
 


### PR DESCRIPTION
## Explain your user case and expected results

I want to use `Unscoped` with a "preload all" to load all associations, but it is not working as expected.

The following fails to load associations which have been soft-deleted:

```go
DB.Preload(clause.Associations, func(db *gorm.DB) *gorm.DB { return db.Unscoped() }).Find(&user, id)
```

While the following (load specific associations by name) succeeds:

```go
DB.Preload("Company", func(db *gorm.DB) *gorm.DB { return db.Unscoped() }).Preload("Manager", func(db *gorm.DB) *gorm.DB { return db.Unscoped() }).Find(&user, id)
```