### PR TITLE
GORM crashes when adding for-update clause.

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Parent{}, &Child{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,13 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.3
+	gorm.io/driver/postgres v1.2.1
+	gorm.io/driver/sqlite v1.2.3
+	gorm.io/driver/sqlserver v1.2.0
+	gorm.io/gorm v1.22.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,14 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	db := DB.Clauses(clause.Locking{Strength: "UPDATE"})
+	var parents []*Parent
+	err := db.Preload("Children").Find(&parents).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	err = db.Delete(&Child{}, "parent_id = 5").Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,21 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Child struct {
+	ID int `gorm:"primaryKey"`
+	ParentID int `gorm:"index"`
+}
+
+func (Child) TableName() string {
+	return "children"
+}
+
+type Parent struct {
+	ID int `gorm:"primaryKey"`
+	Children []*Child `gorm:"foreignkey:ParentID;references:ID"`
+	UpdatedAt time.Time
+	CreatedAt time.Time
+	DeletedAt gorm.DeletedAt
+}
+


### PR DESCRIPTION
- Parent table with relationship to child table
- Parent supports soft delete while child does not.
- Attempt to delete the child causes crash (panic).

## Explain your user case and expected results

Expect gorm not to crash and not have any errors

The following is the result of the test:

./test.sh 
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
remote: Enumerating objects: 164, done.
remote: Counting objects: 100% (164/164), done.
remote: Compressing objects: 100% (156/156), done.
remote: Total 164 (delta 14), reused 35 (delta 4), pack-reused 0
Receiving objects: 100% (164/164), 175.97 KiB | 1.03 MiB/s, done.
Resolving deltas: 100% (14/14), done.
testing sqlite...
2021/11/08 14:54:57 testing sqlite3...
=== RUN   TestGORM

2021/11/08 14:54:57 /home/oamizur/gorm/playground/main_test.go:15
[0.174ms] [rows:0] SELECT * FROM `parents` WHERE `parents`.`deleted_at` IS NULL 
--- FAIL: TestGORM (0.00s)
panic: reflect: Field index out of range [recovered]
	panic: reflect: Field index out of range

goroutine 10 [running]:
testing.tRunner.func1.2(0xd5d440, 0xed5100)
	/usr/local/go/src/testing/testing.go:1144 +0x49f
testing.tRunner.func1(0xc000093980)
	/usr/local/go/src/testing/testing.go:1147 +0x695
panic(0xd5d440, 0xed5100)
	/usr/local/go/src/runtime/panic.go:971 +0x499
reflect.Value.Field(0xda9c40, 0xc000177400, 0x199, 0x4, 0x5, 0x7f136c89f278, 0x0)
	/usr/local/go/src/reflect/value.go:854 +0x345
gorm.io/gorm/schema.(*Field).setupValuerAndSetter.func4(0xda9c40, 0xc000177400, 0x199, 0x0, 0x0, 0x531800)
	/home/oamizur/gorm/playground/gorm/schema/field.go:450 +0xf7
gorm.io/gorm/schema.(*Field).setupValuerAndSetter.func16(0xda9c40, 0xc000177400, 0x199, 0xdfce40, 0xc00000fe90, 0x199, 0xc00000da40)
	/home/oamizur/gorm/playground/gorm/schema/field.go:829 +0x488
gorm.io/gorm.(*Statement).SetColumn(0xc0004e9180, 0xc0001ef1f0, 0xa, 0xdfce40, 0xc00000fe90, 0xc0004fd5ed, 0x1, 0x1)
	/home/oamizur/gorm/playground/gorm/statement.go:575 +0x83f
gorm.io/gorm.SoftDeleteDeleteClause.ModifyStatement(0xc0004bc000, 0xc0004e9180)
	/home/oamizur/gorm/playground/gorm/soft_delete.go:135 +0x3b0
gorm.io/gorm.(*Statement).AddClause(0xc0004e9180, 0xee9578, 0xc0004bc000)
	/home/oamizur/gorm/playground/gorm/statement.go:251 +0x99
gorm.io/gorm/callbacks.Delete.func1(0xc0004e68d0)
	/home/oamizur/gorm/playground/gorm/callbacks/delete.go:123 +0x209
gorm.io/gorm.(*processor).Execute(0xc0001ec460, 0xc0004e68d0, 0xe06762)
	/home/oamizur/gorm/playground/gorm/callbacks.go:130 +0x38f
gorm.io/gorm.(*DB).Delete(0xc0004e68d0, 0xd73420, 0xc000177400, 0xc0001bbe60, 0x1, 0x1, 0xc0004e68d0)
	/home/oamizur/gorm/playground/gorm/finisher_api.go:365 +0x185
gorm.io/playground.TestGORM(0xc000093980)
	/home/oamizur/gorm/playground/main_test.go:19 +0x34c
testing.tRunner(0xc000093980, 0xe29888)
	/usr/local/go/src/testing/testing.go:1194 +0x203
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1239 +0x5d8
FAIL	gorm.io/playground	0.045s
FAIL

