### PR TITLE
When reusing where condition, previous where clauses are appended to the current query

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Parent{}, &Child{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,14 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.1.3
+	gorm.io/driver/postgres v1.2.1
+	gorm.io/driver/sqlite v1.2.3
+	gorm.io/driver/sqlserver v1.2.0
+	gorm.io/gorm v1.22.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,50 @@ package main
 
 import (
 	"testing"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+func populate(db *gorm.DB) error {
+	parents := []*Parent{
+		{
+			ID: 5,
+		},
+		{
+			ID: 6,
+		},
+		{
+			ID: 7,
+		},
+		{
+			ID: 8,
+		},
+	}
+	return db.Create(&parents).Error
+
+}
+
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err := populate(DB)
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	preparedDB := DB.Where("id <> 0")
+	var parents []*Parent
+	if err = preparedDB.Where("id in (?)", []int{5, 6}).Find(&parents).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(parents) != 2 {
+		t.Errorf("Failed, Expected 2 parents.  Got %d", len(parents))
+	}
+	if err = preparedDB.Where("id in (?)", []int{7, 8}).Find(&parents).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(parents) != 2 {
+		t.Errorf("Failed, Expected 2 parents.  Got %d", len(parents))
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,21 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Child struct {
+	ID int `gorm:"primaryKey"`
+	ParentID int `gorm:"index"`
+}
+
+func (Child) TableName() string {
+	return "children"
+}
+
+type Parent struct {
+	ID int `gorm:"primaryKey"`
+	Children []*Child `gorm:"foreignkey:ParentID;references:ID"`
+	UpdatedAt time.Time
+	CreatedAt time.Time
+	DeletedAt gorm.DeletedAt
+}
+


### PR DESCRIPTION


## Explain your user case and expected results
- This causes the query to become incorrect
- For both queries two rows are expected, but for the second one 0 rows are returned