### PR TITLE
Fail to auto migrate sqlite in Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
 	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gorm.io/driver/mysql v1.0.6
 	gorm.io/driver/postgres v1.1.0
 	gorm.io/driver/sqlite v1.1.4
@@ -17,4 +15,4 @@ require (
 	gorm.io/gorm v1.21.9
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,47 @@
 package main
 
 import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"log"
+	"path"
 	"testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+type User struct {
+	gorm.Model
+	Name      string
+	Age       uint
+	Active    bool
+}
 
 func TestGORM(t *testing.T) {
+	dbPath := path.Join("database.db")
+
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger:      logger.Default.LogMode(logger.Info),
+		PrepareStmt: true,
+	})
+	if err != nil {
+		log.Println(err)
+	}
+
+	err = db.AutoMigrate(&User{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	db.Create(&user)
+
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := db.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
go test main_test.go

```
2021/11/23 11:07:08 C:/Users/Jacky/go/pkg/mod/gorm.io/driver/sqlite@v1.1.4/migrator.go:32
[0.608ms] [rows:-] SELECT count(*) FROM sqlite_master WHERE type='table' AND name="users"
--- FAIL: TestGORM (0.03s)
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x55222e]

goroutine 4 [running]:
testing.tRunner.func1.2({0x61f620, 0x7ec5f0})
        C:/Program Files/Go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        C:/Program Files/Go/src/testing/testing.go:1212 +0x218
panic({0x61f620, 0x7ec5f0})
        C:/Program Files/Go/src/runtime/panic.go:1038 +0x215
database/sql.(*Rows).close(0x0, {0x0, 0x0})
        C:/Program Files/Go/src/database/sql/sql.go:3267 +0x8e
database/sql.(*Rows).Close(0x0)
        C:/Program Files/Go/src/database/sql/sql.go:3263 +0x1d
panic({0x61f620, 0x7ec5f0})
        C:/Program Files/Go/src/runtime/panic.go:1038 +0x215
database/sql.(*Rows).Next(0x0)
        C:/Program Files/Go/src/database/sql/sql.go:2944 +0x27
database/sql.(*Row).Scan(0xc000004f30, {0xc000043bc8, 0x40, 0x1})
        C:/Program Files/Go/src/database/sql/sql.go:3333 +0xb4
gorm.io/driver/sqlite.Migrator.HasTable.func1(0xc0001c5500)
        C:/Users/Jacky/go/pkg/mod/gorm.io/driver/sqlite@v1.1.4/migrator.go:32 +0xac
gorm.io/gorm/migrator.Migrator.RunWithValue({{0xb0, 0xc0001cc360, {0x6a6848, 0xc0001cc390}}}, {0x606360, 0xc00010ad00}, 0xc000043c98)
        C:/Users/Jacky/go/pkg/mod/gorm.io/gorm@v1.21.9/migrator/migrator.go:49 +0x126
gorm.io/driver/sqlite.Migrator.HasTable({{{0x0, 0xc0001cc360, {0x6a6848, 0xc0001cc390}}}}, {0x606360, 0xc00010ad00})
        C:/Users/Jacky/go/pkg/mod/gorm.io/driver/sqlite@v1.1.4/migrator.go:31 +0xe8
gorm.io/gorm/migrator.Migrator.AutoMigrate({{0x0, 0xc000183e30, {0x6a6848, 0xc000183e60}}}, {0xc000189300, 0x0, 0x0})
        C:/Users/Jacky/go/pkg/mod/gorm.io/gorm@v1.21.9/migrator/migrator.go:91 +0x127
gorm.io/gorm.(*DB).AutoMigrate(0x6a67f0, {0xc000189300, 0x1, 0x1})
        C:/Users/Jacky/go/pkg/mod/gorm.io/gorm@v1.21.9/migrator.go:26 +0x43
command-line-arguments.TestGORM(0xc00002bd40)
        //Mac/Home/Desktop/playground/main_test.go:33 +0x206
testing.tRunner(0xc00002bd40, 0x661228)
        C:/Program Files/Go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
        C:/Program Files/Go/src/testing/testing.go:1306 +0x35a
FAIL    command-line-arguments  0.300s
FAIL
```