### PR TITLE
tests: Demonstrate that deleting composite pks isn't quite working

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &ModelWithCompositeKey{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
@@ -105,4 +105,9 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+}
+
+type ModelWithCompositeKey struct {
+	KeyOne string `gorm:"primaryKey"`
+	KeyTwo string `gorm:"primaryKey"`
 }

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.7 // indirect
-	golang.org/x/crypto v0.0.0-20210505212654-3497b51f5e64 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect
+	github.com/jackc/pgx/v4 v4.14.0 // indirect
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gorm.io/driver/mysql v1.0.6
-	gorm.io/driver/postgres v1.1.0
-	gorm.io/driver/sqlite v1.1.4
-	gorm.io/driver/sqlserver v1.0.7
-	gorm.io/gorm v1.21.9
+	gorm.io/driver/mysql v1.2.0
+	gorm.io/driver/postgres v1.2.2
+	gorm.io/driver/sqlite v1.2.6
+	gorm.io/driver/sqlserver v1.2.1
+	gorm.io/gorm v1.22.3
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/hashicorp/go-secure-stdlib/base62"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +18,24 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	id, err := base62.Random(10)
+	if err != nil {
+		t.Fatalf("unable to generate id: %v", err)
+	}
+	id2, err := base62.Random(10)
+	if err != nil {
+		t.Fatalf("unable to generate id: %v", err)
+	}
+	compositeResource := ModelWithCompositeKey{
+		KeyOne: id,
+		KeyTwo: id2,
+	}
+	if err := DB.Create(&compositeResource).Error; err != nil {
+		t.Errorf("errors happened when create: %v", err)
+	}
+	if res := DB.Delete(&compositeResource); res.Error != nil || res.RowsAffected != 1 {
+		t.Errorf("errors happened when delete: %v, affected: %v", res.Error, res.RowsAffected)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

I think, Gorm should generate valid sql and be able to delete resources with composite primary keys.

- created a model with a composite primary key
- created resource with composite key in database
- tried to delete it