### PR TITLE
Regression in datatypes/json v1.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	github.com/jinzhu/now v1.1.4 // indirect
+	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
+	gorm.io/datatypes v1.0.4
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/datatypes"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,36 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	t.Run("json nil", func(t *testing.T) {
+		user := User{
+			Name: "jinzhu",
+			Json: nil,
+		}
 
-	DB.Create(&user)
+		DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+		var result User
+		if err := DB.First(&result, user.ID).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+
+		if result.Json != nil {
+			t.Errorf("Failed, json was nil when saving but is '%v' afer reading'", result.Json)
+		}
+	})
+
+	t.Run("json empty string", func(t *testing.T) {
+		user := User{
+			Name: "jinzhu",
+			Json: datatypes.JSON{},
+		}
+
+		DB.Create(&user)
+
+		var result User
+		if err := DB.First(&result, user.ID).Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+	})
+
 }

--- a/models.go
+++ b/models.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"time"
 
+	"gorm.io/datatypes"
+
 	"gorm.io/gorm"
 )
 
@@ -27,6 +29,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Json      datatypes.JSON
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

With https://github.com/go-gorm/datatypes@v1.0.4 JSON values have unexpected behaviours when nil or empty.

If the datatypes.JSON var is `nil`, GORM will now insert a string `"null"` into the database instead of an actual *`null`* value.
If the datatypes.JSON var is empty (empty byte array) GORM tries to insert an empty string `""`, which fails.