### PR TITLE
cockroachdb & timezone test

### DIFF
--- a/db.go
+++ b/db.go
@@ -56,6 +56,18 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
 		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+	case "cockroach":
+		log.Println("testing cockroach...")
+		uri := "postgres://root:@localhost:9940/gorm?sslmode=disable"
+		db, err = gorm.Open(postgres.Open(uri), &gorm.Config{
+			SkipDefaultTransaction: true,
+			// NowFunc: func() time.Time {
+			// 	// utc, _ := time.LoadLocation("Europe/Rome")
+			// 	// return time.Now().In(utc)
+			// 	cet := time.FixedZone("CET", 3600)
+			// 	return time.Now().In(cet)
+			// },
+		})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;
@@ -105,4 +117,5 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,13 @@ services:
       - POSTGRES_DB=gorm
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
+  cockroach:
+    image: 'cockroachdb/cockroach:latest'
+    ports:
+      - 9940:26257
+    command: start-single-node --insecure
+    volumes:
+     - "${PWD}/cockroach-data/crdb:/cockroach/cockroach-data"
   mssql:
     image: 'mcmoe/mssqldocker:latest'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 9920:5432
     environment:
-      - TZ=Asia/Shanghai
+      - TZ=Europe/Rome
       - POSTGRES_DB=gorm
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6

--- a/main_test.go
+++ b/main_test.go
@@ -23,15 +23,18 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	str, _ := result.CreatedAt.Zone()
-	t.Logf("now: %v, createdAt: %v, Zone: %s", now, result.CreatedAt, str)
+	createdAtZone, CreatedAtOffset := result.CreatedAt.Zone()
+	nowZone, nowOffset := now.Zone()
+	t.Logf("NOW: %v, Created At: %v", now, result.CreatedAt)
+	t.Logf("Created At Zone name: %s, Created At Offset: %d", createdAtZone, CreatedAtOffset)
+	t.Logf("NOW Zone name: %s, NOW Offset: %d", nowZone, nowOffset)
 
 	timeNowString := now.Format("2006-01-02 15:04")
 	createdAtString := result.CreatedAt.Format("2006-01-02 15:04")
 
-	t.Logf("now: %s, createdAt: %s", timeNowString, createdAtString)
+	t.Logf("NOW: %s, Created At: %s", timeNowString, createdAtString)
 
-	if timeNowString == createdAtString {
+	if timeNowString == createdAtString && CreatedAtOffset != nowOffset {
 		t.Errorf("Failed, times cannot be the same with different time zones")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,36 @@ package main
 
 import (
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver, cockroach
 
 func TestGORM(t *testing.T) {
+	// time.Local = time.FixedZone("CET", 3600)
+	// time.Local = time.FixedZone("UTC", 0)
+
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
+	now := time.Now()
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	str, _ := result.CreatedAt.Zone()
+	t.Logf("now: %v, createdAt: %v, Zone: %s", now, result.CreatedAt, str)
+
+	timeNowString := now.Format("2006-01-02 15:04")
+	createdAtString := result.CreatedAt.Format("2006-01-02 15:04")
+
+	t.Logf("now: %s, createdAt: %s", timeNowString, createdAtString)
+
+	if timeNowString == createdAtString {
+		t.Errorf("Failed, times cannot be the same with different time zones")
 	}
 }

--- a/models.go
+++ b/models.go
@@ -12,10 +12,15 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
+	// gorm.Model
+	ID        uint            `gorm:"primarykey"`
+	CreatedAt time.Time       `gorm:"type:timestamp"`
+	UpdatedAt time.Time       `gorm:"type:timestamp"`
+	DeletedAt *gorm.DeletedAt `gorm:"type:timestamp"`
+
 	Name      string
 	Age       uint
-	Birthday  *time.Time
+	Birthday  *time.Time `gorm:"type:timestamp"`
 	Account   Account
 	Pets      []*Pet
 	Toys      []Toy `gorm:"polymorphic:Owner"`

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-dialects=("sqlite" "mysql" "postgres" "sqlserver")
+dialects=("cockroach") # "sqlite" "mysql" "postgres" "sqlserver"
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-dialects=("cockroach") # "sqlite" "mysql" "postgres" "sqlserver"
+dialects=("postgres" "cockroach") # "sqlite" "mysql" "sqlserver"
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then


### PR DESCRIPTION
## Explain your user case and expected results
Database: **cockroachdb**
Timezone: Europe/Rome or any other

When a record is created, the created_at field contains current date and time of this timezone, but after selecting this record using First() function by ID, created_at contains same date and time but with different timezone, in my case +0000 UTC.
Expected 2021-12-14 14:40:04.856988 +0000 UTC or better 2021-12-14 15:40:04.856988 +0100 UTC.

![image](https://user-images.githubusercontent.com/71180446/146019499-28a9690f-b05a-4ad3-8d35-eba6dd4c3154.png)
