### PR TITLE
fail test case for increment in composite key set model

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &CompositeKeyProduct{}, &SingleKeyProduct{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	gorm.io/driver/mysql v1.2.1
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -17,4 +19,42 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestGORMCompositeKey(t *testing.T) {
+	// Insert New record
+	prod := &CompositeKeyProduct{
+		LanguageCode: 56,
+		Code:         "56",
+		Name:         "Test56",
+	}
+
+	nextProd := &SingleKeyProduct{
+		LanguageCode: 200,
+		Code:         "200",
+		Name:         "Test200",
+	}
+
+	res := DB.Create(prod)
+	if res.Error != nil {
+		panic(res.Error)
+	}
+
+	res2 := DB.Create(nextProd)
+	if res2.Error != nil {
+		panic(res2.Error)
+	}
+
+	// fmt.Println(prod)
+	assert.Equal(t, 56, prod.LanguageCode)
+	assert.Equal(t, "56", prod.Code)
+	assert.Equal(t, "Test56", prod.Name)
+	assert.Equal(t, 1, prod.ProductPointID)
+
+	// fmt.Println(nextProd)
+	assert.Equal(t, 200, nextProd.LanguageCode)
+	assert.Equal(t, "200", nextProd.Code)
+	assert.Equal(t, "Test200", nextProd.Name)
+	assert.Equal(t, 1, nextProd.ProductPointID)
+
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,23 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+// Has two primary keys
+type CompositeKeyProduct struct {
+	ProductPointID int       `gorm:"primaryKey;autoIncrement:true;column:product_point_id"`
+	LanguageCode   int       `gorm:"primaryKey;autoIncrement:false;column:language_code"`
+	Code           string    `gorm:"column:code"`
+	Name           string    `gorm:"column:name"`
+	CreatedAt      time.Time `gorm:"column:created_at"`
+	UpdatedAt      time.Time `gorm:"column:updated_at"`
+}
+
+// Has one primary keys
+type SingleKeyProduct struct {
+	ProductPointID int       `gorm:"primaryKey;autoIncrement:true;column:product_point_id"`
+	LanguageCode   int       `gorm:"column:language_code"`
+	Code           string    `gorm:"column:code"`
+	Name           string    `gorm:"column:name"`
+	CreatedAt      time.Time `gorm:"column:created_at"`
+	UpdatedAt      time.Time `gorm:"column:updated_at"`
+}


### PR DESCRIPTION
## Explain your user case and expected results

Use Case:
Define table with multiple primary keys (composite key)
Upon New record insert, Get ID of autoIncrement enabled field. 

Issue:
0 returned for autoIncrement enabled field. (Only when the model has 2 fields using primarykey tag)

Example:
Model Defined
![image](https://user-images.githubusercontent.com/7774984/146316101-6c9b0ee4-0471-49ae-ae58-c09f19a05e71.png)

Test Case:
![image](https://user-images.githubusercontent.com/7774984/146316151-a6e3a7d6-84ea-4279-9ee3-41f6c7af162f.png)

Test Result:
![image](https://user-images.githubusercontent.com/7774984/146316214-b6711e9e-37d9-407e-85e0-940f2ccfdbd4.png)


