### PR TITLE
DB with tablePrefix cannot use Model auto adjust field and Join cannot do `inner join` query and it's not able to set where params.

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm/schema"
 	"log"
 	"math/rand"
 	"os"
@@ -69,7 +70,12 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				TablePrefix:   "_w_test_",
+				SingularTable: true,
+			},
+		})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {

--- a/db.go
+++ b/db.go
@@ -72,7 +72,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		log.Println("testing sqlite3...")
 		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
 			NamingStrategy: schema.NamingStrategy{
-				TablePrefix:   "_w_test_",
+				TablePrefix:   DbTablePrefix,
 				SingularTable: true,
 			},
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -25,7 +25,26 @@ func TestGORM(t *testing.T) {
 }
 
 func TestJoin(t *testing.T) {
+	// When gorm.DB with `TablePrefix` config, the select column cannot match auto like `Model.field`. It's have to use
+	// tool look like `Table` to make table with prefix.
+
+	//adjust
+	uTb := Table{}.Init("user")
+	cTb := Table{}.Init("company")
 	var users []User
+
+	// uTb.Field()
+	fields := uTb.Field("id")
+	fields = append(fields, cTb.Field("name")...)
+
+	DB.Select(fields).
+		//Joins("Company", DB.Where(&Company{Name: "JC.inc"})).
+		Joins("Company").
+		Where(map[string]interface{}{"User.name": "jinzhu"}).
+		Where(DB.Where(&Company{Name: "JC.inc"})).
+		Find(&users)
+
+	// failure
 	DB.Select([]string{"User.id", "Company.Name"}).
 		//Joins("Company", DB.Where(&Company{Name: "JC.inc"})).
 		Joins("Company").

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -17,4 +22,36 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestJoin(t *testing.T) {
+	var users []User
+	DB.Select([]string{"User.id", "Company.Name"}).
+		//Joins("Company", DB.Where(&Company{Name: "JC.inc"})).
+		Joins("Company").
+		Where(map[string]interface{}{"User.name": "jinzhu"}).
+		Where(DB.Where(&Company{Name: "JC.inc"})).
+		Find(&users)
+}
+
+func TestJoin2(t *testing.T) {
+	var users []User
+	db2 := getDbWithoutTablePrefix()
+	db2.Select([]string{"User.id", "Company.Name"}).
+		Joins("Company").
+		Where(map[string]interface{}{"User.name": "jinzhu"}).
+		Where(db2.Model(&Company{Name: "JC.inc"})).
+		Find(&users)
+}
+
+func getDbWithoutTablePrefix() *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
+		NamingStrategy: schema.NamingStrategy{
+			SingularTable: true,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return db
 }

--- a/table.go
+++ b/table.go
@@ -1,0 +1,36 @@
+package main
+
+import "fmt"
+
+const (
+	DbTablePrefix = "_wt_"
+)
+
+type Table struct {
+	name string
+}
+
+// Init 表格名称刷新
+func (t Table) Init(name string) Table {
+	t.name = GetTableNaming(name)
+	return t
+}
+
+// Naming 获取表明
+func (t Table) Naming() string {
+	return t.name
+}
+
+// Field 获取查询字段
+func (t Table) Field(fields ...string) []string {
+	var fld []string
+	for _, f := range fields {
+		fld = append(fld, fmt.Sprintf("%v.%v", t.name, f))
+	}
+	return fld
+}
+
+
+func GetTableNaming(tb string) string {
+	return fmt.Sprintf("%v%v", DbTablePrefix, tb)
+}


### PR DESCRIPTION
## Explain your user case and expected results
In my case, the project have to set tablePrefix and when I code it fand it's hand.

- A) DB with tablePrefix cannot use Model auto adjust field
- B) Join cannot do `inner join` query
- C) it's not able to set where params.

> Like that. 


`select` hard to carry on tablePrefix and cannot make `inner join`  query. 
```go
// _wt_
DB.Select([]string{"User.id", "Company.name"}).
		//Joins("Company", DB.Where(&Company{Name: "JC.inc"})).
		Joins("Company").
		Where(map[string]interface{}{"User.name": "jinzhu"}).
		Where(DB.Where(&Company{Name: "JC.inc"})).
		Find(&users)
```

SQL like(tablePrefix=`_wt_`):

```sql
select _wt_user.id,  _wt_company.name from _wt_user 
     innr join _wt_company where _wt_user.company_id = _wt_company .id
     where _wt_company.name='JC.inc'
;

```
