### PR TITLE
many2many error on conflict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
-	gorm.io/driver/mysql v1.2.1
+	github.com/mattn/go-sqlite3 v1.14.10 // indirect
+	github.com/satori/go.uuid v1.2.0
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	gorm.io/driver/mysql v1.2.3
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/driver/sqlserver v1.2.1

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,89 @@
 package main
 
 import (
+	"fmt"
+	"gorm.io/gorm"
 	"testing"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Application struct {
+	ID        string `gorm:"primarykey"`
+	Name      string
+	Type      string
+	Resources []Resource `json:"resources,omitempty" gorm:"many2many:application_resources;" faker:"-"`
+}
+
+type Resource struct {
+	ID       string `gorm:"primarykey"`
+	Name     string
+	Type     string
+	Packages []Package `json:"packages,omitempty" gorm:"many2many:resource_packages;" faker:"-"`
+}
+
+type Package struct {
+	ID   string `gorm:"primarykey"`
+	Name string
+	Type string
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	if err := DB.AutoMigrate(&Application{}, Resource{}, Package{}); err != nil {
+		t.Fatalf("Failed to run auto migration: %v", err)
+	}
 
-	DB.Create(&user)
+	// Creates an application
+	app := createApp(uuid.NewV4().String())
+	if err := DB.Create(&app).Error; err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err := update(&app); err != nil {
+		t.Fatalf("failed to update application: %v", err)
+	}
+}
+
+func update(app *Application) error {
+	// Updates application with 2 resources pointing to the same package and save to DB
+	newApp := *app
+	newApp.Resources = []Resource{createResource("1"), createResource("2")}
+	if err := DB.Session(&gorm.Session{FullSaveAssociations: true}).
+		Save(newApp).Error; err != nil {
+
+		// We failed here due to
+		// ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
+		//[2.167ms] [rows:0] INSERT INTO "packages" ("id","name","type") VALUES ('1','name','type'),('1','name','type') ON CONFLICT ("id") DO UPDATE SET "name"="excluded"."name","type"="excluded"."type"
+		return fmt.Errorf("failed to save application: %v", err)
+	}
+	return nil
+}
+
+func createApp(id string) Application {
+	return Application{
+		ID:   id,
+		Name: "name",
+		Type: "type",
+	}
+}
+
+func createResource(id string) Resource {
+	return Resource{
+		ID:       id,
+		Name:     "name",
+		Type:     "type",
+		Packages: []Package{createPackage("1")},
+	}
+}
+
+func createPackage(id string) Package {
+	return Package{
+		ID:   id,
+		Name: "name",
+		Type: "type",
 	}
 }


### PR DESCRIPTION
## Many2many error on conflict
I use many2many models
```
type Application struct {
	ID        string `gorm:"primarykey"`
	Name      string
	Type      string
	Resources []Resource `json:"resources,omitempty" gorm:"many2many:application_resources;" faker:"-"`
}

type Resource struct {
	ID       string `gorm:"primarykey"`
	Name     string
	Type     string
	Packages []Package `json:"packages,omitempty" gorm:"many2many:resource_packages;" faker:"-"`
}

type Package struct {
	ID   string `gorm:"primarykey"`
	Name string
	Type string
}
```
In my case there is a single application with 2 resources that **associate to the same package**.
The application update flow with `FullSaveAssociations: true` failed due to
```
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
[2.167ms] [rows:0] INSERT INTO "packages" ("id","name","type") VALUES ('1','name','type'),('1','name','type') ON CONFLICT ("id") DO UPDATE SET "name"="excluded"."name","type"="excluded"."type"
```

Instead of inserting only a single `package` GORM tries to insert the same duplicate `package - ('1','name','type')`  in a single INSERT command

I would expect that the save command would not failed and that only single `package` will be inserted.

Maybe there is a way to remove duplicates values **before** creating the INSERT statement for `Associations`