### PR TITLE
ARRAY[?] receives an unexpected parenthesis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.16
 
 require (
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
-	gorm.io/driver/mysql v1.2.1
+	github.com/mattn/go-sqlite3 v1.14.10 // indirect
+	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
+	gorm.io/driver/mysql v1.2.3
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/driver/sqlserver v1.2.1


### PR DESCRIPTION
## Explain your user case and expected results

I'm running the test cases for only Postgres dialect (`GORM_DIALECT=postgres go test`) and I would expect to work both cases, but unfortunately the latter one doesn't work, the slice of IDs receives an extra parenthesis, which makes the query fail.

```sql
SELECT "users"."id","users"."created_at","users"."updated_at","users"."deleted_at","users"."name","users"."age","users"."birthday","users"."company_id","users"."manager_id","users"."active" FROM "users" JOIN unnest(ARRAY[(2,1,3)]::int[]) WITH ORDINALITY AS x(id, order_nr) ON x.id = users.id WHERE "users"."deleted_at" IS NULL ORDER BY x.order_nr
```