### PR TITLE
Scopes that makes a subquery

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,37 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user1 := User{Name: "jinzhu", Age: 35}
+	user2 := User{Name: "ortolo", Age: 36}
+	user3 := User{Name: "foobar", Age: 42}
 
-	DB.Create(&user)
+	DB.Create(&user1)
+	DB.Create(&user2)
+	DB.Create(&user3)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.First(&result, user1.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+
+	subQueryScope := func(db *gorm.DB) *gorm.DB {
+		return db.Table("(?) AS sub", db.Model(&User{}))
+	}
+
+	var users []*User
+	if err := DB.Scopes(subQueryScope).Find(&users).Error; err != nil {
+		t.Errorf("Query with a subquery-making scope failed, got error: %v", err)
+	}
+
+
+	weirdSubQueryScope := func(db *gorm.DB) *gorm.DB {
+		// Note the use of DB.Model(), where DB is *not* the argument
+		// given to this scope but the global variable!
+		return db.Table("(?) AS sub", DB.Model(&User{}))
+	}
+
+	if err := DB.Scopes(weirdSubQueryScope).Find(&users).Error; err != nil {
+		t.Errorf("Query with a weird subquery-making scope failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
This adds code to test the behaviour of a scope that uses a subquery.

The first tested scope, named `subQueryScope`, uses its provided `*gorm.DB` to define a minimal subquery. That results in an invalid SQL, with a missing table name and unbalanced parentheses, that fails to execute.

The second tested scope, named `subQueryScope`, does the same, except it uses the _global_ `*gorm.DB` variable to select the model to work with. That results in correct SQL, that executes without problem.