### PR TITLE
NameReplacer: strings.NewReplacer("Model", "")

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"gorm.io/gorm/schema"
 	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gorm.io/driver/mysql"
@@ -69,7 +71,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				NameReplacer: strings.NewReplacer("Model", ""),
+			},
+		})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {


### PR DESCRIPTION
当struct中使用gorm.Model时
NameReplacer: strings.NewReplacer("Model", "") 会报错