### PR TITLE
Migrator Panic at Polymorphic Relationship and no PK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,31 +2,12 @@ version: '3'
 
 services:
   mysql:
-    image: 'mysql:latest'
+    image: 'mysql/mysql-server:latest'
     ports:
-      - 9910:3306
+      - "9910:3306"
     environment:
       - MYSQL_DATABASE=gorm
       - MYSQL_USER=gorm
       - MYSQL_PASSWORD=gorm
       - MYSQL_RANDOM_ROOT_PASSWORD="yes"
-  postgres:
-    image: 'postgres:latest'
-    ports:
-      - 9920:5432
-    environment:
-      - TZ=Asia/Shanghai
-      - POSTGRES_DB=gorm
-      - POSTGRES_USER=gorm
-      - POSTGRES_PASSWORD=gorm
-  mssql:
-    image: 'mcmoe/mssqldocker:latest'
-    ports:
-      - 9930:1433
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=LoremIpsum86
-      - MSSQL_DB=gorm
-      - MSSQL_USER=gorm
-      - MSSQL_PASSWORD=LoremIpsum86
 

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.0 // indirect
 	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
-	gorm.io/driver/mysql v1.2.1
+	github.com/mattn/go-sqlite3 v1.14.11 // indirect
+	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
+	gorm.io/driver/mysql v1.2.3
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/driver/sqlserver v1.2.1
-	gorm.io/gorm v1.22.4
+	gorm.io/gorm v1.22.5
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,27 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
+
+type Tag struct {
+	gorm.Model
+	OwnerID uint
+	OwnerType string
+}
+
+type Foo struct {
+	TagID uint
+	Tag Tag `gorm:"polymorphic:Owner;polymorphicValue:foo"`
+}
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err := DB.AutoMigrate(&Tag{}, &Foo{}); err != nil {
+		t.Error(err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,8 @@ type Tag struct {
 }
 
 type Foo struct {
+	// An ID field solves the panic.
+	// ID uint
 	TagID uint
 	Tag Tag `gorm:"polymorphic:Owner;polymorphicValue:foo"`
 }


### PR DESCRIPTION
Migrator causes panic when a table with no PK has a polymorphic relationship