### PR TITLE
Create test to show Omit inserts empty data for 'has one' relationships

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,19 +4,11 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.0 // indirect
-	github.com/jackc/pgx/v4 v4.15.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.11 // indirect
-	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
-	gorm.io/driver/mysql v1.2.3
-	gorm.io/driver/postgres v1.2.3
-	gorm.io/driver/sqlite v1.2.6
-	gorm.io/driver/sqlserver v1.2.1
-	gorm.io/gorm v1.22.5
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
+	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064 // indirect
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/postgres v1.3.1
 	gorm.io/driver/sqlite v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/jackc/pgx/v4 v4.14.1 // indirect
-	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
-	gorm.io/driver/mysql v1.2.1
+	github.com/denisenkom/go-mssqldb v0.12.0 // indirect
+	github.com/jackc/pgx/v4 v4.15.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.11 // indirect
+	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
+	gorm.io/driver/mysql v1.2.3
 	gorm.io/driver/postgres v1.2.3
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/driver/sqlserver v1.2.1
-	gorm.io/gorm v1.22.4
+	gorm.io/gorm v1.22.5
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,37 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// GORM_BRANCH: v1.22.5
+// TEST_DRIVERS: mysql
 
 func TestGORM(t *testing.T) {
+	account := Account{Number: "1"}
+	DB.Create(&account)
+
 	user := User{Name: "jinzhu"}
+	user.Account = account
 
-	DB.Create(&user)
+	// Causes this: INSERT INTO `accounts` VALUES() ON DUPLICATE KEY UPDATE `user_id`=VALUES(`user_id`)
+	// This will create an empty account
+	DB.Omit("Account.*").Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	var accounts []Account
+	DB.Find(&accounts)
+
+	if len(accounts) != 1 {
+		fmt.Print("Num Accounts")
+		fmt.Println(len(accounts))
+
+		for _, a := range accounts {
+			fmt.Print("Account number: ") // one of these will be an empty string
+			fmt.Println(a.Number)
+		}
+		t.Error("unexpected accounts")
+		t.Fail()
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: v1.22.5
+// GORM_BRANCH: v1.23.3
 // TEST_DRIVERS: mysql
 
 func TestGORM(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -13,15 +13,27 @@ func TestGORM(t *testing.T) {
 	account := Account{Number: "1"}
 	DB.Create(&account)
 
+	manager := User{Name: "jinzhu"}
+	DB.Create(&manager)
+
 	user := User{Name: "jinzhu"}
 	user.Account = account
+	user.Manager = &manager
 
-	// Causes this: INSERT INTO `accounts` VALUES() ON DUPLICATE KEY UPDATE `user_id`=VALUES(`user_id`)
-	// This will create an empty account
-	DB.Omit("Account.*").Create(&user)
+	// Causes this:
+	// 	INSERT INTO `accounts` VALUES() ON DUPLICATE KEY UPDATE `user_id`=VALUES(`user_id`)
+	//  INSERT INTO `users` VALUES() ON DUPLICATE KEY UPDATE `id`=`id`
+	// This will create an empty account and user
+	DB.Omit("Account.*,Manager.*").Create(&user)
 
 	var accounts []Account
 	DB.Find(&accounts)
+
+	var users []User
+	DB.Find(&users)
+
+	fmt.Println("LEN USERS: ")
+	fmt.Println(len(users))
 
 	if len(accounts) != 1 {
 		fmt.Print("Num Accounts")
@@ -32,6 +44,10 @@ func TestGORM(t *testing.T) {
 			fmt.Println(a.Number)
 		}
 		t.Error("unexpected accounts")
+		t.Fail()
+	}
+
+	if len(users) != 2 {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
## Omit  will insert empty rows instead of avoiding upsert

Objects with a 'has one' relationship - during a `Create` with an `Omit` clause will still run the `insert` statement but with all empty values. This actually creates an empty record in the database.

I would expect `Omit("...*")` to completely avoid doing an upsert on the association listed.