### PR TITLE
Select breaks Distinct

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,17 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user1 := User{Name: "jinzhu", Age: 42}
+	user2 := User{Name: "jinzhu", Age: 99}
 
-	DB.Create(&user)
+	DB.Create(&user1)
+	DB.Create(&user2)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	results := []User{}
+	if err := DB.Distinct("name").Select("name", "age").Scan(&results).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d. %#v", len(results), results)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -17,11 +17,19 @@ func TestGORM(t *testing.T) {
 	DB.Create(&user1)
 	DB.Create(&user2)
 
-	results := []User{}
-	if err := DB.Model(&User{}).Distinct("name").Select("name", "age").Scan(&results).Error; err != nil {
+	correctResults := []User{}
+	if err := DB.Raw("SELECT DISTINCT(name), age FROM users").Scan(&correctResults).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 	if len(results) != 1 {
-		t.Errorf("Expected 1 result, got %d. %#v", len(results), results)
+		t.Errorf("Expected 1 result, got %d. %v", len(correctResults), correctResults)
+	}
+
+	actualResults := []User{}
+	if err := DB.Model(&User{}).Distinct("name").Select("name", "age").Scan(&actualResults).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(actualResults) != 1 {
+		t.Errorf("Expected 1 result, got %d. %v", len(actualResults), actualResults)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func TestGORM(t *testing.T) {
 	DB.Create(&user2)
 
 	results := []User{}
-	if err := DB.Distinct("name").Select("name", "age").Scan(&results).Error; err != nil {
+	if err := DB.Model(&User{}).Distinct("name").Select("name", "age").Scan(&results).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 	if len(results) != 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestGORM(t *testing.T) {
 	if err := DB.Raw("SELECT DISTINCT(name), age FROM users").Scan(&correctResults).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
-	if len(results) != 1 {
+	if len(correctResults) != 1 {
 		t.Errorf("Expected 1 result, got %d. %v", len(correctResults), correctResults)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+
+
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver


### PR DESCRIPTION
## Explain your user case and expected results

`.Distinct` should enforce only returning unique results.