### PR TITLE
Select Joins combined with same 'where' conditions twice when called 'Scan' more than two times

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Parent{}, &Child{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.11 // indirect
+	github.com/mattn/go-sqlite3 v1.14.12 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	gorm.io/driver/mysql v1.3.0
-	gorm.io/driver/postgres v1.3.0
-	gorm.io/driver/sqlite v1.3.0
-	gorm.io/driver/sqlserver v1.3.0
-	gorm.io/gorm v1.23.0
+	gorm.io/driver/mysql v1.3.2
+	gorm.io/driver/postgres v1.3.1
+	gorm.io/driver/sqlite v1.3.1
+	gorm.io/driver/sqlserver v1.3.1
+	gorm.io/gorm v1.23.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"testing"
 )
 
@@ -9,12 +10,33 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	parent := Parent{
+		ID:1,
+		Name: "name1",
+		Children: []Child{
+			{ChildID:2, ParentID: 1, ChildName: "Child1"},
+			{ChildID:3, ParentID: 1, ChildName: "Child2"},
+			{ChildID:4, ParentID: 1, ChildName: "Child3"},
+		},
+	}
 
-	DB.Create(&user)
+	parent2 := Parent{
+		ID:2,
+		Name: "name2",
+		Children: []Child{
+			{ChildID:5, ParentID: 2, ChildName: "Child4"},
+			{ChildID:6, ParentID: 2, ChildName: "Child5"},
+			{ChildID:6, ParentID: 2, ChildName: "Child6"},
+		},
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	DB.Create(&parent)
+	DB.Create(&parent2)
+
+	var result Parent
+	if err := DB.Model(&result).Select("*").Joins("LEFT JOIN children ON children.parent_id = parents.id").Where("parents.id = ?", 1).Scan(&result).Scan(&result.Children).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	log.Println(result)
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,15 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Parent struct {
+	ID int `gorm:"primarykey"`
+	Name string
+	Children []Child
+}
+
+type Child struct{
+	ChildID int `gorm:"primarykey"`
+	ParentID int
+	ChildName string
+}


### PR DESCRIPTION
## Explain your user case and expected results

### Model
```
type Parent struct {
	ID int `gorm:"primarykey"`
	Name string
	Children []Child
}

type Child struct{
	ChildID int `gorm:"primarykey"`
	ParentID int
	ChildName string
}
```


### Case

When I tried to get parent and its child by using Joins and Where, the same where condition combined twice time 

### Expected Result:
```
2022/03/05 00:48:27 /home/hidetomo8111f/playground/main_test.go:50
[6.669ms] [rows:1] SELECT * FROM "parents" LEFT JOIN children ON children.parent_id = parents.id WHERE parents.id = 1

2022/03/05 00:48:27 /home/hidetomo8111f/playground/main_test.go:50
[2.311ms] [rows:3] SELECT * FROM "parents" LEFT JOIN children ON children.parent_id = parents.id WHERE parents.id = 1 
2022/03/05 00:48:27 {1 name1 [{1 1 Child1} {2 1 Child2} {3 1 Child3}]}

```

### What I get:
```
2022/03/05 00:48:27 /home/hidetomo8111f/playground/main_test.go:50
[6.669ms] [rows:1] SELECT * FROM "parents" LEFT JOIN children ON children.parent_id = parents.id WHERE parents.id = 1

2022/03/05 00:48:27 /home/hidetomo8111f/playground/main_test.go:50
[2.311ms] [rows:3] SELECT * FROM "parents" LEFT JOIN children ON children.parent_id = parents.id WHERE parents.id = 1 AND "parents"."id" = 1
2022/03/05 00:48:27 {1 name1 [{1 1 Child1} {2 1 Child2} {3 1 Child3}]}

```

