### PR TITLE
feat: reproduction case for 'SELECT SUM(column)' of decimals

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&Transaction{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.11 // indirect
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	gorm.io/driver/mysql v1.3.0
-	gorm.io/driver/postgres v1.3.0
-	gorm.io/driver/sqlite v1.3.0
-	gorm.io/driver/sqlserver v1.3.0
-	gorm.io/gorm v1.23.0
+	github.com/mattn/go-sqlite3 v1.14.12 // indirect
+	github.com/shopspring/decimal v1.3.1
+	golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70 // indirect
+	gorm.io/driver/mysql v1.3.2
+	gorm.io/driver/postgres v1.3.1
+	gorm.io/driver/sqlite v1.3.1
+	gorm.io/driver/sqlserver v1.3.1
+	gorm.io/gorm v1.23.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/shopspring/decimal"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,29 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	transactions := []Transaction{
+		{Amount: decimal.NewFromFloat(17.99)},
+		{Amount: decimal.NewFromFloat(17.99)},
+		{Amount: decimal.NewFromFloat(17.99)},
+		{Amount: decimal.NewFromFloat(17.99)},
+		{Amount: decimal.NewFromFloat(17.99)},
+	}
 
-	DB.Create(&user)
+	for _, transaction := range transactions {
+		DB.Create(&transaction)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	var result decimal.Decimal
+
+	err := DB.Table("transactions").Select(
+		"SUM(amount)",
+	).Row().Scan(&result)
+
+	if err != nil {
+		t.Errorf("'SELECT SUM(amount)' Failed, got error: %v", err)
+	}
+
+	if !result.Equals(decimal.NewFromFloat(89.95)) {
+		t.Errorf("SUM(amount) is not 89.95, got %s", result)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,11 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
+	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
+type Transaction struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Amount decimal.Decimal `json:"amount" gorm:"type:DECIMAL(20,8);"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

My use case is saving money and then loading off as much of the calculation on the database as a database is usually more performant than the implementation I could write.

This test does the following:

* Create 5 `Transaction` objects with an `Amount` of `17.99` each. This is a decimal in the database.
* Run a `SELECT SUM(amount)` query over the table

This should equal `89.95`.

This passes for postgres, but fails for sqlite. (I can’t test mssql and mysql as both don’t run on Apple M1 devices yet)
Running the query on the sqlite database directly however returns the correct result:

```sh
❯ echo $TMPDIR
/var/folders/mz/5b4wqvv90w5_qpjsprq86b7w0000gn/T/
❯ sqlite3 /var/folders/mz/5b4wqvv90w5_qpjsprq86b7w0000gn/T/gorm.db
SQLite version 3.36.0 2021-06-18 18:58:49
Enter ".help" for usage hints.
sqlite> .schema transactions
CREATE TABLE `transactions` (`id` integer,`created_at` datetime,`updated_at` datetime,`deleted_at` datetime,`amount` DECIMAL(20,8),PRIMARY KEY (`id`));
CREATE INDEX `idx_transactions_deleted_at` ON `transactions`(`deleted_at`);
sqlite> select sum(amount) from transactions;
89.95
```