### PR TITLE
version v1.23.x run AutoMigrate more than once, will occur error.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,12 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.12 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/postgres v1.3.1
 	gorm.io/driver/sqlite v1.3.1
 	gorm.io/driver/sqlserver v1.3.1
-	gorm.io/gorm v1.23.1
+	gorm.io/gorm v1.23.3
 )
-
-replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -9,12 +10,15 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	if err := DB.Transaction(func(tx *gorm.DB) error {
+		return tx.AutoMigrate(&User{})
+	}); err != nil {
+		t.Error(err)
+	}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err := DB.Transaction(func(tx *gorm.DB) error {
+		return tx.AutoMigrate(&User{})
+	}); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

```text
=== RUN   TestGORM

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:145
[5.422ms] [rows:1] SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = 'companies' AND table_type = 'BASE TABLE'

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:20
[0.521ms] [rows:1] SELECT CURRENT_DATABASE()

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:330
[4.221ms] [rows:-] SELECT c.column_name, c.is_nullable = 'YES', c.udt_name, c.character_maximum_length, c.numeric_precision, c.numeric_precision_radix, c.numeric_scale, c.datetime_precision, 8 * typlen, c.column_default, pd.description FROM information_schema.columns AS c JOIN pg_type AS pgt ON c.udt_name = pgt.typname LEFT JOIN pg_catalog.pg_description as pd ON pd.objsubid = c.ordinal_position AND pd.objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = c.table_name AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = c.table_schema)) where table_catalog = 'postgres' AND table_schema = CURRENT_SCHEMA() AND table_name = 'companies'

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:331 driver: bad connection
[7.975ms] [rows:-] SELECT * FROM "companies" LIMIT 1

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:164 ERROR: column "id" of relation "companies" already exists (SQLSTATE 42701)
[0.522ms] [rows:0] ALTER TABLE "companies" ADD "id" bigserial
    main_test.go:16: ERROR: column "id" of relation "companies" already exists (SQLSTATE 42701)

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:145
[1.080ms] [rows:1] SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = 'companies' AND table_type = 'BASE TABLE'

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:20
[0.060ms] [rows:1] SELECT CURRENT_DATABASE()

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:330
[4.383ms] [rows:-] SELECT c.column_name, c.is_nullable = 'YES', c.udt_name, c.character_maximum_length, c.numeric_precision, c.numeric_precision_radix, c.numeric_scale, c.datetime_precision, 8 * typlen, c.column_default, pd.description FROM information_schema.columns AS c JOIN pg_type AS pgt ON c.udt_name = pgt.typname LEFT JOIN pg_catalog.pg_description as pd ON pd.objsubid = c.ordinal_position AND pd.objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = c.table_name AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = c.table_schema)) where table_catalog = 'postgres' AND table_schema = CURRENT_SCHEMA() AND table_name = 'companies'

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:331 driver: bad connection
[0.000ms] [rows:-] SELECT * FROM "companies" LIMIT 1

2022/03/19 15:28:24 D:/Work/GOPATH/pkg/mod/gorm.io/driver/postgres@v1.3.1/migrator.go:164 ERROR: column "id" of relation "companies" already exists (SQLSTATE 42701)
[0.517ms] [rows:0] ALTER TABLE "companies" ADD "id" bigserial
    main_test.go:22: ERROR: column "id" of relation "companies" already exists (SQLSTATE 42701)
--- FAIL: TestGORM (0.03s)

FAIL
```