### PR TITLE
With Postgres, fail to create records with belongs_to association.

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Game{}, &Set{}, &Article{}, &Product{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
+	github.com/pioz/faker v1.7.2
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/postgres v1.3.1
 	gorm.io/driver/sqlite v1.3.1

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"testing"
+
+	"github.com/pioz/faker"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql, postgres
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	faker.SetSeed(1) // Get determinist output
+	products := make([]Product, 100)
+	faker.Build(&products)
+	err := DB.Create(&products).Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,35 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	ID       uint64 `faker:"-"`
+	Username string
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
+type Game struct {
+	ID   uint64 `faker:"-"`
 	Name string
 }
 
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Set struct {
+	ID         uint64 `faker:"-"`
+	GameID     uint64 `faker:"-"`
+	Name       string
+	ParentCode string `gorm:"default:(-)"`
+	Game       *Game
+}
+
+type Article struct {
+	ID    uint64 `faker:"-"`
+	SetID uint64 `faker:"-"`
+	Name  string
+	Set   *Set
+}
+
+type Product struct {
+	ID        uint64 `faker:"-"`
+	UserID    uint64 `faker:"-"`
+	ArticleID uint64 `faker:"-"`
+	Code      string
+	User      *User
+	Article   *Article
 }


### PR DESCRIPTION
## Explain your user case and expected results

A query fails to create (in this example `articles`) because the `set_id` column (foreign key) is set to 0 and breaks the constraint. This happened, I think, because the previous query that inserts the `sets` returns not only the `id`, but also the column `parent_code`: `ON CONFLICT DO NOTHING RETURNING "parent_code","id"`

On MySQL the test passed.

This is strange behavior for an ORM library that which the same code works with a driver (MySQL) and fails with another (Postgresql).