### PR TITLE
Upsert with has_many association

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Article{}, &ArticleName{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/postgres v1.3.1
 	gorm.io/driver/sqlite v1.3.1

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,190 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	var r interface{}
+	DB.Raw("DELETE FROM article_names").Scan(r)
+	DB.Raw("DELETE FROM articles").Scan(r)
 
-	DB.Create(&user)
+	articles := []*Article{
+		{
+			Code: "123",
+			ArticleNames: []*ArticleName{
+				{Name: "Jacket", Language: "en"},
+				{Name: "Giacca", Language: "it"},
+			},
+		},
+		{
+			Code: "456",
+			ArticleNames: []*ArticleName{
+				{Name: "Shirt", Language: "en"},
+				{Name: "Maglietta", Language: "it"},
+			},
+		},
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err := DB.Clauses(clause.OnConflict{UpdateAll: true}).
+		Session(&gorm.Session{CreateBatchSize: 1000, FullSaveAssociations: true}).
+		Create(&articles).Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	err = DB.Preload("ArticleNames").Find(&articles).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(articles) != 2 {
+		t.Errorf("Expected 2 articles, found %d", len(articles))
+	}
+	if articles[0].Code != "123" {
+		t.Errorf("Expected article 1 with code 123, found %s", articles[0].Code)
+	}
+	if len(articles[0].ArticleNames) != 2 {
+		t.Errorf("Expected article 1 with 2 names, found %d", len(articles[0].ArticleNames))
+	}
+	if articles[0].ArticleNames[0].Name != "Jacket" {
+		t.Errorf("Expected Jacket, get %s", articles[0].ArticleNames[0].Name)
+	}
+	if articles[0].ArticleNames[1].Name != "Giacca" {
+		t.Errorf("Expected Giacca, get %s", articles[0].ArticleNames[1].Name)
+	}
+	if articles[1].Code != "456" {
+		t.Errorf("Expected article 2 with code 456, found %s", articles[1].Code)
+	}
+	if len(articles[1].ArticleNames) != 2 {
+		t.Errorf("Expected article 2 with 2 names, found %d", len(articles[1].ArticleNames))
+	}
+	if articles[1].ArticleNames[0].Name != "Shirt" {
+		t.Errorf("Expected Shirt, get %s", articles[1].ArticleNames[0].Name)
+	}
+	if articles[1].ArticleNames[1].Name != "Maglietta" {
+		t.Errorf("Expected Maglietta, get %s", articles[1].ArticleNames[1].Name)
+	}
+
+	// Do it again
+
+	articles = []*Article{
+		{
+			Code: "123",
+			ArticleNames: []*ArticleName{
+				{Name: "Jacket", Language: "en"},
+				{Name: "Giacca", Language: "it"},
+			},
+		},
+		{
+			Code: "456",
+			ArticleNames: []*ArticleName{
+				{Name: "Shirt", Language: "en"},
+				{Name: "Maglietta", Language: "it"},
+			},
+		},
+	}
+
+	err = DB.Clauses(clause.OnConflict{UpdateAll: true}).
+		Session(&gorm.Session{CreateBatchSize: 1000, FullSaveAssociations: true}).
+		Create(&articles).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	err = DB.Preload("ArticleNames").Find(&articles).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(articles) != 2 {
+		t.Errorf("Expected 2 articles, found %d", len(articles))
+	}
+	if articles[0].Code != "123" {
+		t.Errorf("Expected article 1 with code 123, found %s", articles[0].Code)
+	}
+	if len(articles[0].ArticleNames) != 2 {
+		t.Errorf("Expected article 1 with 2 names, found %d", len(articles[0].ArticleNames))
+	}
+	if articles[0].ArticleNames[0].Name != "Jacket" {
+		t.Errorf("Expected Jacket, get %s", articles[0].ArticleNames[0].Name)
+	}
+	if articles[0].ArticleNames[1].Name != "Giacca" {
+		t.Errorf("Expected Giacca, get %s", articles[0].ArticleNames[1].Name)
+	}
+	if articles[1].Code != "456" {
+		t.Errorf("Expected article 2 with code 456, found %s", articles[1].Code)
+	}
+	if len(articles[1].ArticleNames) != 2 {
+		t.Errorf("Expected article 2 with 2 names, found %d", len(articles[1].ArticleNames))
+	}
+	if articles[1].ArticleNames[0].Name != "Shirt" {
+		t.Errorf("Expected Shirt, get %s", articles[1].ArticleNames[0].Name)
+	}
+	if articles[1].ArticleNames[1].Name != "Maglietta" {
+		t.Errorf("Expected Maglietta, get %s", articles[1].ArticleNames[1].Name)
+	}
+
+	// Do it again with updated values
+
+	articles = []*Article{
+		{
+			Code: "123",
+			ArticleNames: []*ArticleName{
+				{Name: "Jacket", Language: "en"},
+				{Name: "Giacca", Language: "it"},
+			},
+		},
+		{
+			Code: "456bis",
+			ArticleNames: []*ArticleName{
+				{Name: "T-Shirt", Language: "en"},
+				{Name: "Maglietta", Language: "it"},
+			},
+		},
+	}
+
+	err = DB.Clauses(clause.OnConflict{UpdateAll: true}).
+		Session(&gorm.Session{CreateBatchSize: 1000, FullSaveAssociations: true}).
+		Create(&articles).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	err = DB.Preload("ArticleNames").Find(&articles).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(articles) != 2 {
+		t.Errorf("Expected 2 articles, found %d", len(articles))
+	}
+	if articles[0].Code != "123" {
+		t.Errorf("Expected article 1 with code 123, found %s", articles[0].Code)
+	}
+	if len(articles[0].ArticleNames) != 2 {
+		t.Errorf("Expected article 1 with 2 names, found %d", len(articles[0].ArticleNames))
+	}
+	if articles[0].ArticleNames[0].Name != "Jacket" {
+		t.Errorf("Expected Jacket, get %s", articles[0].ArticleNames[0].Name)
+	}
+	if articles[0].ArticleNames[1].Name != "Giacca" {
+		t.Errorf("Expected Giacca, get %s", articles[0].ArticleNames[1].Name)
+	}
+	if articles[1].Code != "456bis" {
+		t.Errorf("Expected article 2 with code 456bis, found %s", articles[1].Code)
+	}
+	if len(articles[1].ArticleNames) != 3 {
+		t.Errorf("Expected article 2 with 3 names, found %d", len(articles[1].ArticleNames))
+	} else {
+		if articles[1].ArticleNames[0].Name != "Shirt" {
+			t.Errorf("Expected Shirt, get %s", articles[1].ArticleNames[0].Name)
+		}
+		if articles[1].ArticleNames[1].Name != "Maglietta" {
+			t.Errorf("Expected Maglietta, get %s", articles[1].ArticleNames[1].Name)
+		}
+		if articles[1].ArticleNames[2].Name != "T-Shirt" {
+			t.Errorf("Expected T-Shirt, get %s", articles[1].ArticleNames[2].Name)
+		}
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,17 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Article struct {
+	ID           uint64
+	Code         string `gorm:"index:idx_code,unique"`
+	ArticleNames []*ArticleName
+}
+
+type ArticleName struct {
+	ID        uint64
+	ArticleID uint64
+	Name      string `gorm:"index:idx_name,unique"`
+	Language  string
+	Article   *Article
+}


### PR DESCRIPTION
## Explain your user case and expected results

In this sample, I have a model `Article` with the field `code` that is indexed with a unique index. An article has many article names. So I have another model `ArticleName` with the foreign key to the article table `article_id`, a field `name` that is indexed with a unique index (the unique indices in this sample, are useful to perform upsert operations).

I want to ask if it is possible to upsert articles and article names as follow:

```go
// Models

type Article struct {
	ID           uint64
	Code         string `gorm:"index:idx_code,unique"`
	ArticleNames []*ArticleName
}

type ArticleName struct {
	ID        uint64
	ArticleID uint64
	Name      string `gorm:"index:idx_name,unique"`
	Language  string
	Article   *Article
}

// Creation

articles := []*Article{
		{
			Code: "123",
			ArticleNames: []*ArticleName{
				{Name: "Jacket", Language: "en"},
				{Name: "Giacca", Language: "it"},
			},
		},
		{
			Code: "456",
			ArticleNames: []*ArticleName{
				{Name: "Shirt", Language: "en"},
				{Name: "Maglietta", Language: "it"},
			},
		},
	}

DB.Clauses(clause.OnConflict{UpdateAll: true}).
		Session(&gorm.Session{FullSaveAssociations: true}).
		Create(&articles)

// Update (case no changes)

articles = []*Article{
		{
			Code: "123",
			ArticleNames: []*ArticleName{
				{Name: "Jacket", Language: "en"},
				{Name: "Giacca", Language: "it"},
			},
		},
		{
			Code: "456",
			ArticleNames: []*ArticleName{
				{Name: "Shirt", Language: "en"},
				{Name: "Maglietta", Language: "it"},
			},
		},
	}

DB.Clauses(clause.OnConflict{UpdateAll: true}).
		Session(&gorm.Session{FullSaveAssociations: true}).
		Create(&articles)

// Update (case with changes)

articles = []*Article{
		{
			Code: "123",
			ArticleNames: []*ArticleName{
				{Name: "Jacket", Language: "en"},
				{Name: "Giacca", Language: "it"},
			},
		},
		{
			Code: "456bis",
			ArticleNames: []*ArticleName{
				{Name: "T-Shirt", Language: "en"},
				{Name: "Maglietta", Language: "it"},
			},
		},
	}

DB.Clauses(clause.OnConflict{UpdateAll: true}).
		Session(&gorm.Session{FullSaveAssociations: true}).
		Create(&articles)

```
Now the first `DB.Create` works and creates the 2 articles with names as expected. 🤟
The second `DB.Create` returns the following error:
```
Error 1452: Cannot add or update a child row: a foreign key constraint fails (`gorm`.`article_names`, CONSTRAINT `fk_articles_article_names` FOREIGN KEY (`article_id`) REFERENCES `articles` (`id`))
[5.139ms] [rows:0] INSERT INTO `article_names` (`article_id`,`name`,`language`) VALUES (0,'Jacket','en'),(0,'Giacca','it'),(0,'Shirt','en'),(0,'Maglietta','it') ON DUPLICATE KEY UPDATE `article_id`=VALUES(`article_id`),`name`=VALUES(`name`),`language`=VALUES(`language`)
```
As you can see, the `article_id` value is set to `0`. How to avoid this?

Then the third `DB.Create` returns the following error:
```
Error 1452: Cannot add or update a child row: a foreign key constraint fails (`gorm`.`article_names`, CONSTRAINT `fk_articles_article_names` FOREIGN KEY (`article_id`) REFERENCES `articles` (`id`))
[8.834ms] [rows:0] INSERT INTO `article_names` (`article_id`,`name`,`language`) VALUES (5,'Jacket','en'),(5,'Giacca','it'),(6,'T-Shirt','en'),(6,'Maglietta','it') ON DUPLICATE KEY UPDATE `article_id`=VALUES(`article_id`),`name`=VALUES(`name`),`language`=VALUES(`language`)
```
In this case, the `article_id` is set to `4` and `5`, but these articles do not exist.

Do you know how to pass the test I wrote in the linked playground?

@jinzhu heeeeeeeeeelppppppp 🙏