### PR TITLE
Gorm V2 cannot handle join for tables with same column name

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Employee{}, &CompanyEmployeeJunction{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,76 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type CompanyEmployeeInfo struct {
+	Company  *Company  `gorm:"embedded"`
+	Employee *Employee `gorm:"embedded"`
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	RunMigrations()
 
-	DB.Create(&user)
+	company1 := Company{Name: "Apple"}
+	company2 := Company{Name: "Meta"}
+	company3 := Company{Name: "Amazon"}
+	company4 := Company{Name: "Tesla"}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	DB.Create(&company1)
+	DB.Create(&company2)
+	DB.Create(&company3)
+	DB.Create(&company4)
+
+	employee1 := Employee{Name: "Harold"}
+	employee2 := Employee{Name: "John"}
+	employee3 := Employee{Name: "Tom"}
+	employee4 := Employee{Name: "Harry"}
+
+	DB.Create(&employee1)
+	DB.Create(&employee2)
+	DB.Create(&employee3)
+	DB.Create(&employee4)
+
+	DB.Create(&CompanyEmployeeJunction{CompanyID: company1.ID, EmployeeID: employee3.ID})
+	DB.Create(&CompanyEmployeeJunction{CompanyID: company1.ID, EmployeeID: employee4.ID})
+	DB.Create(&CompanyEmployeeJunction{CompanyID: company2.ID, EmployeeID: employee1.ID})
+	DB.Create(&CompanyEmployeeJunction{CompanyID: company2.ID, EmployeeID: employee3.ID})
+
+	var companyEmployeeInfoList []*CompanyEmployeeInfo
+	if err := DB.Select("companies.*, employees.*").
+		Table("companies").
+		Joins("inner join company_employee_junctions on companies.id = company_employee_junctions.company_id").
+		Joins("inner join employees on company_employee_junctions.employee_id = employees.id").
+		Find(&companyEmployeeInfoList).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	companyMatched := false
+	employeeMatched := false
+
+	for _, info := range companyEmployeeInfoList {
+		if info.Company == nil {
+			t.Fatalf("Failed, expected not nil, got company nil")
+		}
+		if info.Employee == nil {
+			t.Fatalf("Failed, expected not nil, got employee nil")
+		}
+		if info.Company.ID == company1.ID {
+			companyMatched = true
+			if info.Company.Name != company1.Name {
+				t.Fatalf("Failed, expected %v, got %v", company1.Name, info.Company.Name)
+			}
+		}
+		if info.Employee.ID == employee1.ID {
+			employeeMatched = true
+			if info.Employee.Name != employee1.Name {
+				t.Fatalf("Failed, expected %v, got %v", company1.Name, info.Company.Name)
+			}
+		}
+	}
+
+	if !companyMatched {
+		t.Fatalf("Failed, no company matched")
+	}
+	if !employeeMatched {
+		t.Fatalf("Failed, no employee matched")
 	}
 }

--- a/models.go
+++ b/models.go
@@ -50,8 +50,19 @@ type Toy struct {
 }
 
 type Company struct {
-	ID   int
+	gorm.Model
 	Name string
+}
+
+type Employee struct {
+	gorm.Model
+	Name string
+}
+
+type CompanyEmployeeJunction struct {
+	gorm.Model
+	CompanyID  uint `gorm:"primaryKey"`
+	EmployeeID uint `gorm:"primaryKey"`
 }
 
 type Language struct {


### PR DESCRIPTION
## Explain your user case and expected results

If two tables have the same column names like `id` and `name`, once we perform the `JOIN` query with a junction table in between, we see that the library does not populate the right value into the right struct. This happens due to how value is scanned back to the struct.