### PR TITLE
Bug report: third automigrate in tx causes error in postgres

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
-	gorm.io/driver/mysql v1.3.2
-	gorm.io/driver/postgres v1.3.1
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
+	gorm.io/driver/mysql v1.3.3
+	gorm.io/driver/postgres v1.3.3
 	gorm.io/driver/sqlite v1.3.1
-	gorm.io/driver/sqlserver v1.3.1
+	gorm.io/driver/sqlserver v1.3.2
 	gorm.io/gorm v1.23.3
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+	"time"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,45 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	type AutoMigrateInTx struct{}
+	_ = DB.Migrator().DropTable(&AutoMigrateInTx{})
+	err := DB.Transaction(func(tx *gorm.DB) error {
+		err := func() error {
+			type AutoMigrateInTx struct {
+				First time.Time
+			}
+			return tx.Migrator().AutoMigrate(&AutoMigrateInTx{})
+		}()
+		if err != nil {
+			return err
+		}
+		err = func() error {
+			type AutoMigrateInTx struct {
+				First  time.Time
+				Second time.Time
+			}
+			return tx.Migrator().AutoMigrate(&AutoMigrateInTx{})
+		}()
+		if err != nil {
+			return err
+		}
+		err = func() error {
+			type AutoMigrateInTx struct {
+				First  time.Time
+				Second time.Time
+				Third  time.Time
+			}
+			return tx.Migrator().AutoMigrate(&AutoMigrateInTx{})
+		}()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("not expecting error, got: %v", err)
+	}
+	if !DB.Table("auto_migrate_in_tx").Migrator().HasColumn(&AutoMigrateInTx{}, "third") {
+		t.Fatalf("expecting the third column to be present")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
The third auto migrate in a transaction on the same table causes an error in postgres.
> /go/pkg/mod/gorm.io/driver/postgres@v1.3.3/migrator.go:461 ERROR: cached plan must not change result type (SQLSTATE 0A000)

Expected behavior: one can auto migrate the same table multiple times.