### PR TITLE
operator does not exist: date >= integer

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +15,15 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var u User
+
+	err := DB.
+		Select("max(id)").
+		Where("date(created_at) >= date(now()) - ?", 0).
+		Group("date(created_at)").
+		Find(&u)
+
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"testing"
-
-	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}


### PR DESCRIPTION
## Explain your user case and expected results

On PostgreSQL 14.2, was comparing date in a `where` clause, but get:

```
ERROR: operator does not exist: date >= integer (SQLSTATE 42883)
```

The comparison should work since `date(now()) - 0` returns a date type (via psql), but somehow in gorm, it evaluates as an integer type.
