### PR TITLE
Belongs to foreign key field cannot be set to primary key of assigned struct

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Vehicle{}, &ParkingSpot{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/jackc/pgx/v4 v4.15.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
-	gorm.io/driver/mysql v1.3.2
-	gorm.io/driver/postgres v1.3.1
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
+	gorm.io/driver/mysql v1.3.3
+	gorm.io/driver/postgres v1.3.4
 	gorm.io/driver/sqlite v1.3.1
-	gorm.io/driver/sqlserver v1.3.1
-	gorm.io/gorm v1.23.3
+	gorm.io/driver/sqlserver v1.3.2
+	gorm.io/gorm v1.23.4
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,7 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	vehicle := Vehicle{VehicleID: "id-1"}
+	DB.Create(&vehicle)
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,13 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Vehicle struct {
+	VehicleID string `gorm:"primarykey"`
+}
+
+type ParkingSpot struct {
+	ID        string `gorm:"primarykey"`
+	VehicleID string
+	Vehicle   Vehicle `gorm:"foreignKey:VehicleID"`
+}


### PR DESCRIPTION
## Explain your user case and expected results
**User case**
The primary key of a struct may contain the struct name as a substring.
For instance: Vehicle with pk VehicleID, User with pk Username, etc.
You may want to create a struct that belongs to the previous struct

```go
type Vehicle struct {
	VehicleID string `gorm:"primarykey"`
}

type ParkingSpot struct {
	ID        string `gorm:"primarykey"`
	VehicleVehicleID string
	Vehicle   Vehicle
}
```
but the field `VehicleVehicleID` is pedantic. The [instructions to override foreign key](https://gorm.io/docs/belongs_to.html#Override-Foreign-Key) do not work in this case.
```go
type ParkingSpot struct {
	ID        string `gorm:"primarykey"`
	VehicleID string
	Vehicle   Vehicle `gorm:"foreignKey:VehicleID"`
}
```

**Expected results**
Special syntax to allow this naming convention, or if infeasible, documentation that the foreign key field cannot be equal to the primary key of the assigned struct.