### PR TITLE
returning a list of structs with a interface field

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,20 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	userTwo := User{Name: "second"}
+
+	DB.Create(&userTwo)
+
+	var users []User
+	if err := DB.Find(&users).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if len(users) != 2 {
+		t.Errorf("Expected length 2 go: %v", len(users))
+	}
+
+	if users[0].ExternalKey == users[1].ExternalKey {
+		t.Errorf("Expected externalKey to be different got: %v", users[0].ExternalKey)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
+	"math/rand"
+	"reflect"
 	"time"
 
 	"gorm.io/gorm"
@@ -13,20 +16,21 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	Name        string
+	Age         uint
+	Birthday    *time.Time
+	Account     Account
+	Pets        []*Pet
+	Toys        []Toy `gorm:"polymorphic:Owner"`
+	CompanyID   *int
+	Company     Company
+	ManagerID   *uint
+	Manager     *User
+	Team        []User     `gorm:"foreignkey:ManagerID"`
+	Languages   []Language `gorm:"many2many:UserSpeak"`
+	Friends     []*User    `gorm:"many2many:user_friends"`
+	Active      bool
+	ExternalKey interface{} `gorm:"type:varchar (36)""`
 }
 
 type Account struct {
@@ -57,4 +61,24 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+func (user *User) BeforeCreate(tx *gorm.DB) (err error) {
+	rand.Seed(time.Now().UnixNano())
+	random := rand.Intn(30-10+1) + 10
+	user.ExternalKey = fmt.Sprintf("%d", random)
+	return
+}
+
+func (user *User) AfterFind(tx *gorm.DB) (err error) {
+	//user.ExternalKey is **interface{}
+	tempID := reflect.Indirect(reflect.Indirect(reflect.ValueOf(user.ExternalKey))).Interface()
+	external, ok := tempID.([]uint8)
+	if ok {
+		user.ExternalKey = string(external)
+		return
+	}
+	user.ExternalKey = tempID
+
+	return
 }


### PR DESCRIPTION
## Explain your user case and expected results
Using a field as interface{} on Find returns **interface{} and for a list will point to same location 
```
type User struct {
	gorm.Model
	...
	ExternalKey interface{} `gorm:"type:varchar (36)""`
}
```
Expect to have different values in different structs
