### PR TITLE
bug report sharding model auto migrate

### DIFF
--- a/db.go
+++ b/db.go
@@ -49,13 +49,17 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 		}
-		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+		})
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+		})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;
@@ -66,10 +70,10 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "sqlserver://gorm:LoremIpsum86@localhost:9930?database=gorm"
 		}
-		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {
@@ -83,7 +87,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/models.go
+++ b/models.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
@@ -13,48 +10,12 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
 	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
+	Orders []Order
 }
 
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Order struct {
+	ID      int64 `gorm:"primarykey"`
+	UserID  int64
+	Product string
 }


### PR DESCRIPTION
## Explain your user case and expected results
I using `DisableForeignKeyConstraintWhenMigrating:true` mode and i want to `AutoMigrate` sharding table.
```go
type Order struct {
	ID      int64 `gorm:"primarykey"`
	UserID  int64
	Product string
}

DB.Table("order_0").AutoMigrate(&Order{})
DB.Table("order_1").AutoMigrate(&Order{}) // success
....
```
it work If it is not associated with other modes
```go
type User struct {
	gorm.Model
	Name   string
	Orders []Order
}

type Order struct {
	ID      int64 `gorm:"primarykey"`
	UserID  int64
	Product string
}

DB.Table("order_0").AutoMigrate(&Order{})
DB.Table("order_1").AutoMigrate(&Order{}) // panic
``` 
