### PR TITLE
Reproduce postgres auto-migration bug

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,39 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+func CreateObject() error {
+	type Object struct{}
+	return DB.AutoMigrate(&Object{})
+}
+
+func AddField1() error {
+	type Object struct {
+		Field1 string
+	}
+	return DB.AutoMigrate(&Object{})
+}
+
+func AddField2() error {
+	type Object struct {
+		Field2 string
+	}
+	return DB.AutoMigrate(&Object{})
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if DB.Dialector.Name() != "postgres" {
+		return
+	}
+	if err := CreateObject(); err != nil {
+		t.Errorf("FAILED CREATING OBJECT")
+		return
+	}
+	if err := AddField1(); err != nil {
+		t.Errorf("FAILED ADDING FIELD1")
+		return
+	}
+	if err := AddField2(); err != nil {
+		t.Errorf("I am sad :(")
+		return
 	}
 }


### PR DESCRIPTION
Reproduce failure to migrate the same model more than twice with the
postgres driver.
ERROR: cached plan must not change result type (SQLSTATE 0A000)

**ISSUE:** https://github.com/go-gorm/postgres/issues/102

## Explain your user case and expected results
I have multiple migration steps which operate on the same object on a `postgres` database.
The third step fails but running just two of the migration steps does not fail, there doesn't seem to be anything special about the migration I am performing, not sure why this should happen.
This error occurs for `gorm` on version `1.23.5` but does not for version `1.23.4`