### PR TITLE
Beginning transaction when statement not empty can cause issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
@@ -11,6 +12,7 @@ require (
 	gorm.io/driver/sqlite v1.3.2
 	gorm.io/driver/sqlserver v1.3.2
 	gorm.io/gorm v1.23.4
+	gorm.io/plugin/soft_delete v1.1.0
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"testing"
 )
 
@@ -10,11 +11,10 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	account := Account{UserID: sql.NullInt64{Int64: int64(user.ID), Valid: true}}
+	DB.Create(&account)
+
+	DB.Delete(&user)
 }


### PR DESCRIPTION
Within a Hook I would like to do some deletion within a transaction.

I would expect this code to work, however it panics.

The cause of the issue seem to be that the transaction create a session with NewDB = false instead of true in finisher_api.go:593

In my example, this cause the code to panic because in the transaction, the statement refer to the table `user` when deleting the `account`.
So it uses the `StatementModifier` of `user` instead of the one of `account`
As account uses soft_delete.DeletedAt and user use gorm.DeletedAt, gorm tries to set a time in account's DeletedAt which is a uint and panic.