### PR TITLE
Triggers failure trying to use nested transactions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,10 +11,16 @@ import (
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	tx := DB.Begin()
+	tx2 := tx.Begin()
+	tx2.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := tx2.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	if err := tx2.Commit().Error; err != nil {
+		t.Errorf("Failed to commit: %v", err)
+	}
+	tx.Commit()
 }


### PR DESCRIPTION
## Explain your user case and expected results

It appears that nested transactions aren't support using the manual `db.Begin`/`db.Commit` transaction methods, and are only supported using the `db.Transaction(function(...` block style of transactions.

I'm using transactions in my unit test suite to provide per-test data isolation. I have a test suite type:

```go
type TestSuite {
  DB *gorm.DB
  ...
}
```

And I have `SetupTest` and `AfterTest` functions on that suite that run before and after each test to open and rollback a DB transaction to isolate the test:

```go
func (suite *TestSuite) BeforeTest() {
  ...
  suite.DB = db.Begin()
}

func (suite *TestSuite) AfterTest() {
  ...
 suite.DB.Rollback()
}
```

Within the application code exercised by the tests I make normal use of DB transactions, also using the `db.Begin`/`db.Close` method. When that code is run as a nested transaction by the test suite the DB interactions all fail with `ErrInvalidTransaction` when I would assume they would work correctly due to Gorm's support for nested transactions  