### PR TITLE
Json datatypes gets corrupted on fetch multiple

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
+	github.com/mattn/go-sqlite3 v1.14.13 // indirect
+	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	gorm.io/datatypes v1.0.7-0.20220517022917-c244d2875ae0
+	gorm.io/driver/mysql v1.3.4
+	gorm.io/driver/postgres v1.3.7
 	gorm.io/driver/sqlite v1.3.2
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.5
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"gorm.io/datatypes"
+	"reflect"
 	"testing"
 )
 
@@ -8,16 +10,84 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Param struct {
+	ID          int
+	DisplayName string
+	Config      datatypes.JSON
+}
+
 func TestGORM(t *testing.T) {
-	var pets []*Pet
 
-	err := DB.
-		Joins("INNER JOIN users ON users.id = pets.user_id").
-		Where(&Pet{Name: "a"}).
-		Where(&User{Age: 10}).
-		Find(&pets).Error
+	DB.Exec("DROP TABLE IF EXISTS `params`")
 
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	DB.Exec("CREATE TABLE `params` (`id` tinyint NOT NULL, `display_name` varchar(64) NOT NULL, `config` json DEFAULT NULL, PRIMARY KEY (`id`))")
+
+	DB.Exec("INSERT INTO `params` (`id`,`display_name`,`config`) VALUES (1,'Test1','{\"val1\": 987654, \"val2\": \"abcdefghijklmnopqrstuvwxyz\"}');")
+
+	DB.Exec("INSERT INTO `params` (`id`,`display_name`,`config`) VALUES (2,'TEST_JSON','{\"param1\": 1234, \"param2\": \"test\"}')")
+
+	fetchId := 2
+
+	cmp1 := Param{
+		ID:          fetchId,
+		DisplayName: "TEST_JSON",
+		Config:      datatypes.JSON("{\"param1\": 1234, \"param2\": \"test\"}"),
+	}
+
+	var retSingle1 Param
+
+	err := DB.Where("id = ?", fetchId).Take(&retSingle1).Error
+	if err != nil || reflect.DeepEqual(retSingle1, Param{}) {
+		t.Fatalf("error when fetching single 1: %v", err)
+	}
+
+	t.Logf("received: %v", retSingle1)
+
+	if !reflect.DeepEqual(retSingle1, cmp1) {
+		t.Fatalf("received not equal to expected #1. Received: %v, expected: %v", retSingle1, cmp1)
+	}
+
+	var retSingle2 Param
+
+	err = DB.Where("id = ?", fetchId).Take(&retSingle2).Error
+	if err != nil || reflect.DeepEqual(retSingle2, Param{}) {
+		t.Fatalf("error when fetching single 2: %v", err)
+	}
+
+	t.Logf("received: %v", retSingle2)
+
+	if !reflect.DeepEqual(retSingle2, cmp1) {
+		t.Fatalf("received not equal to expected #2. Received: %v, expected: %v", retSingle2, cmp1)
+	}
+
+	if !reflect.DeepEqual(retSingle2, retSingle1) {
+		t.Fatalf("received not equal to expected #2. Received: %v, expected: %v", retSingle2, retSingle1)
+	}
+
+	var retMultiple []Param
+
+	err = DB.Order("id ASC").Find(&retMultiple).Error
+	if err != nil || reflect.DeepEqual(retMultiple, Param{}) {
+		t.Fatalf("error when fetching multiple: %v", err)
+	}
+
+	t.Logf("received slice: %v", retMultiple)
+	t.Logf("got previously #1: %v", retSingle1)
+	t.Logf("got previously #2: %v", retSingle2)
+
+	if len(retMultiple) != 2 {
+		t.Fatalf("expected 2 items, got: %v", len(retMultiple))
+	}
+
+	if !reflect.DeepEqual(retSingle1, cmp1) {
+		t.Fatalf("the received value is not equal to the expected value #1. Received: %v, expected: %v", retSingle1, cmp1)
+	}
+
+	if !reflect.DeepEqual(retSingle2, cmp1) {
+		t.Fatalf("the received value is not equal to the expected value #2. Received: %v, expected: %v", retSingle2, cmp1)
+	}
+
+	if !reflect.DeepEqual(retMultiple[len(retMultiple)-1], cmp1) {
+		t.Fatalf("the received slice item is not equal to the expected item. Received: %v, expected: %v", retMultiple[len(retMultiple)-1], cmp1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,15 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	var pets []*Pet
 
-	DB.Create(&user)
+	err := DB.
+		Joins("INNER JOIN users ON users.id = pets.user_id").
+		Where(&Pet{Name: "a"}).
+		Where(&User{Age: 10}).
+		Find(&pets).Error
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if err != nil {
+		t.Fatalf("err: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
Fetching JSON slice corrupts previously fetched JSON. Happens in MySQL but not in sqlite.
This error doesn't happen on gorm.io/datatypes v1.0.6 but does happen after this commit:
go get gorm.io/datatypes@c244d2875ae06d92f7f0765444f297b8aced0a08

sqlite (pass test)
```
    main_test.go:74: received slice: [{1 Test1 {"val1": 987654, "val2": "abcdefghijklmnopqrstuvwxyz"}} {2 TEST_JSON {"param1": 1234, "param2": "test"}}]
    main_test.go:75: got previously #1: {2 TEST_JSON {"param1": 1234, "param2": "test"}}
    main_test.go:76: got previously #2: {2 TEST_JSON {"param1": 1234, "param2": "test"}}
--- PASS: TestGORM (0.02s)
PASS
ok      gorm.io/playground      1.323s
testing mysql...
2022/06/06 17:53:07 testing mysql...
=== RUN   TestGORM
```

MySQL (fail test)
```
    main_test.go:74: received slice: [{1 Test1 {"val1": 987654, "val2": "abcdefghijklmnopqrstuvwxyz"}} {2 TEST_JSON {"param1": 1234, "param2": "test"}}]
    main_test.go:75: got previously #1: {2 TEST_JSON 1": 987654, "val2": "abcdefghijklm}
    main_test.go:76: got previously #2: {2 TEST_JSON {"param1": 1234, "param2": "test"}}
    main_test.go:83: the received value is not equal to the expected value #1. Received: {2 TEST_JSON 1": 987654, "val2": "abcdefghijklm}, expected: {2 TEST_JSON {"param1": 12
34, "param2": "test"}}
--- FAIL: TestGORM (0.07s)
FAIL
FAIL    gorm.io/playground      1.065s
FAIL
```

