### PR TITLE
CREATE TABLE is run multiple times

### DIFF
--- a/db.go
+++ b/db.go
@@ -87,12 +87,12 @@ func RunMigrations() {
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
-	DB.Migrator().DropTable("user_friends", "user_speaks")
-
-	if err = DB.Migrator().DropTable(allModels...); err != nil {
-		log.Printf("Failed to drop table, got error %v\n", err)
-		os.Exit(1)
-	}
+	/*
+		if err = DB.Migrator().DropTable(allModels...); err != nil {
+			log.Printf("Failed to drop table, got error %v\n", err)
+			os.Exit(1)
+		}
+	*/
 
 	if err = DB.AutoMigrate(allModels...); err != nil {
 		log.Printf("Failed to auto migrate, but got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.14 // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	gorm.io/driver/mysql v1.3.4
+	gorm.io/driver/postgres v1.3.7
+	gorm.io/driver/sqlite v1.3.5
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.6
 )
 
 replace gorm.io/gorm => ./gorm


### PR DESCRIPTION
## Explain your user case and expected results
When there's no table, everything is fine.

When a table exists already, the migrator wants to delete it and recreate it about as many times as there are columns. This shouldn't happen.

I'm running `test.sh` as:
```
GORM_DIALECT=sqlite DEBUG=true ./test.sh
```

My use case is sqlite, so I haven't seen this with mysql or postgres, but `./test.sh` seems to not see it with mysql or postgres either.