### PR TITLE
AutoMigrate fails if a table with dash in name exists in sqlite

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,18 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestTableNameWithDash(t *testing.T) {
+	table := &TableNameWithDash{}
+
+	if err := DB.Migrator().DropTable(table); err != nil {
+		t.Fatalf("Failed to drop table, got error %v\n", err)
+	}
+
+	if err := DB.AutoMigrate(&TableNameWithDash{}); err != nil {
+		t.Fatalf("Failed to migrate, got error %v\n", err)
+	}
+	if err := DB.AutoMigrate(&TableNameWithDash{}); err != nil {
+		t.Errorf("Failed to re-migrate, got error %v\n", err)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -58,3 +58,11 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type TableNameWithDash struct {
+	gorm.Model
+}
+
+func (*TableNameWithDash) TableName() string {
+	return "test-dash"
+}


### PR DESCRIPTION
## Explain your user case and expected results

`AutoMigrate()` fails if a table with `-` in name exists in sqlite.