### PR TITLE
FindInBatches fail when using multiple primaryKey.

### DIFF
--- a/db.go
+++ b/db.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
-	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -83,9 +81,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
+	allModels := []interface{}{&User{}}
 
 	DB.Migrator().DropTable("user_friends", "user_speaks")
 

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.14 // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	gorm.io/driver/mysql v1.3.4
+	gorm.io/driver/postgres v1.3.8
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
-replace gorm.io/gorm => ./gorm
+// replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,17 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
+	user := User{Name: "jinzhu", Gender: 1, Cond: "test"}
+	user2 := User{Name: "jinzhu", Gender: 2, Cond: "test"}
 	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	DB.Create(&user2)
+	value := []User{}
+	err := DB.Where("cond = ?", "test").FindInBatches(&value, 1, func(tx *gorm.DB, batch int) error {
+		// Do something...
+		// error occurs in FindInBatches
+		return nil
+	}).Error
+	if err != nil {
+		t.Errorf("%+v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"database/sql"
-	"time"
+	// "database/sql"
+	// "time"
 
-	"gorm.io/gorm"
+	// "gorm.io/gorm"
 )
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
@@ -12,49 +12,8 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Name   string `gorm:"primaryKey"`
+	Gender int    `gorm:"primaryKey"`
+	Cond   string
+	// fields2 string
 }


### PR DESCRIPTION
## Explain your user case and expected results
FindInBatches works depends on sorting primaryKey.
when model has more primaryKeys, FindInBatches should use first primaryKeys as sort condition.
while in schema/schema.go:217. set `PrioritizedPrimaryField` has bug.
```
if schema.PrioritizedPrimaryField == nil && len(schema.PrimaryFields) == 1 {
	schema.PrioritizedPrimaryField = schema.PrimaryFields[0]
}
```

in gorm.io docs. `PrioritizedPrimaryField` described as "// Prioritized primary key field: field with DB name `id` or the first defined primary key" in Write Plugins chapter. 
please check this out.
correct code should be like:
```
if schema.PrioritizedPrimaryField == nil && len(schema.PrimaryFields) >= 1 {
	schema.PrioritizedPrimaryField = schema.PrimaryFields[0]
}
```