### PR TITLE
Check AutoMigrate sets correct type for int64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.14 // indirect
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 // indirect
+	gorm.io/driver/mysql v1.3.5
+	gorm.io/driver/postgres v1.3.8
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/driver/sqlserver"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +13,66 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	// Check that AutoMigrate will resolve column type mismatches
+	checkGoProp := "ManagerID"
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	t.Logf("Type of migrator %T", DB.Migrator())
+
+	// Get the expected type based on the dialect
+	var expectedType string
+
+	// Load the schema
+	DB.Statement.Parse(&User{})
+	field := DB.Statement.Schema.LookUpField(checkGoProp)
+
+	// Get column types from particular drivers
+	switch m := DB.Migrator().(type) {
+	case postgres.Migrator:
+		expectedType = m.DataTypeOf(field)
+	case sqlite.Migrator:
+		expectedType = m.DataTypeOf(field)
+	case sqlserver.Migrator:
+		expectedType = m.DataTypeOf(field)
+	default:
+		// Don't check other types
+		return
+	}
+
+	expectedType = DB.Migrator().FullDataTypeOf(field).SQL
+	columnName := field.DBName
+
+	// Get type from database
+	columnTypes, err := DB.Migrator().ColumnTypes(&User{})
+	if err != nil {
+		t.Fatalf("Failed to read column types %s", err)
+	}
+	var actualType string
+	for _, columnType := range columnTypes {
+		if columnType.Name() == columnName {
+			actualType = columnType.DatabaseTypeName()
+		}
+	}
+
+	// Same type?
+	if expectedType != actualType {
+		t.Logf("Type mismatch %s != %s, running auto migration", expectedType, actualType)
+	}
+
+	DB.AutoMigrate(&User{})
+
+	// Reread and compare types
+	columnTypes, err = DB.Migrator().ColumnTypes(&User{})
+	if err != nil {
+		t.Fatalf("Failed to read column types %s", err)
+	}
+	for _, columnType := range columnTypes {
+		if columnType.Name() == columnName {
+			actualType = columnType.DatabaseTypeName()
+		}
+	}
+
+	if expectedType != actualType {
+		t.Fatalf("AutoMigrate failed to resolve type mismatch: %s != %s. ALTER COLUMN will be called every AutoMigrate but never resolve the mismatch.", expectedType, actualType)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

If a GORM field is of type int64, the postgres driver will translate this to a column type "bigint". However, the Postgres Migrator will always read the column type from the database as int8 (the actual Postgres column type).

This will result in every call to AutoMigrate firing a type mismatch and firing an invalid/redundant ALTER COLUMN.