### PR TITLE
use ip as field prefix

### DIFF
--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	IPV4      string `gorm:"ipv4"`
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results
```
IPV4 string `gorm:"ipv4"`
```
```
INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`,`ip_v4`) VALUES ('2022-08-02 21:47:08.8','2022-08-02 21:47:08.8',NULL,'jinzhu',0,NULL,NULL,NULL,false,'')
```
[https://github.com/go-gorm/gorm/issues/5569](https://github.com/go-gorm/gorm/issues/5569)