### PR TITLE
Show scan regression where same object is returned

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &UserAvatar{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.14 // indirect
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	gorm.io/driver/mysql v1.3.5
+	gorm.io/driver/postgres v1.3.8
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,52 @@ package main
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	tomID := uuid.New().String()
+	DB.Create(&User{
+		ID:   tomID,
+		Name: "tom",
+	})
 
-	DB.Create(&user)
+	bobID := uuid.New().String()
+	DB.Create(&User{
+		ID:   bobID,
+		Name: "bob",
+	})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	DB.Create(&UserAvatar{
+		ID:     uuid.New().String(),
+		UserID: tomID,
+		Size:   1337,
+	})
+
+	DB.Create(&UserAvatar{
+		ID:     uuid.New().String(),
+		UserID: bobID,
+		Size:   2674,
+	})
+
+	var usersRoomAvatars usersRoomAvatars
+	d := DB.Table("users").
+		Select(
+			"users.*",
+			"user_avatars.id as avatar_id",
+			"user_avatars.user_id as avatar_user_id",
+			"user_avatars.size as avatar_size").
+		Joins("left join user_avatars on user_avatars.user_id = users.id").
+		Group("users.id, user_avatars.id")
+
+	d.Scan(&usersRoomAvatars)
+
+	for _, ua := range usersRoomAvatars {
+		t.Logf("avatar ID: %s", ua.Avatar.ID)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,21 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	ID     string      `gorm:"column:id;type:varchar(36);primary_key" json:"id"`
+	Name   string      `gorm:"column:name;type:varchar(255);not null" json:"name"`
+	Avatar *UserAvatar `gorm:"foreignKey:UserID;constraint:OnDelete:SET NULL"`
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
+type UserAvatar struct {
+	ID     string `gorm:"column:id;type:varchar(36);primary_key" json:"id"`
+	UserID string `gorm:"column:user_id;type:varchar(36);uniqueIndex" json:"userID"`
+	Size   int64  `gorm:"column:size;type:bigint" json:"size"`
 }
 
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
+type userRoomAvatar struct {
+	User
+	Avatar *UserAvatar `gorm:"embedded;embeddedPrefix:avatar_"`
+	RoomID string
 }
 
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
-}
+type usersRoomAvatars []userRoomAvatar


### PR DESCRIPTION
Attempting to load associated UserAvatar objects with  `Joins` and `Scan` but the objects returned are same. I would expect the avatar associated with each user to be different. Output from this test shows:

```
main_test.go:51: user name: bob avatar ID: 7c3a0265-313d-422e-a486-f33e208f8de7
main_test.go:51: user name: tom avatar ID: 7c3a0265-313d-422e-a486-f33e208f8de7
```

Downgrading to gorm v1.23.5 fixes. This seems to be the commit that caused the regression: https://github.com/go-gorm/gorm/commit/d01de7232b46987e239ef19a89d9ab192f453894
