### PR TITLE
`Scan` panics when passed pointer to pointer to array

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,17 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/google/uuid v1.3.0
+	github.com/jackc/pgx/v4 v4.17.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 // indirect
+	gorm.io/driver/mysql v1.3.6
+	gorm.io/driver/postgres v1.3.9
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +18,12 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestScanToArray(t *testing.T) {
+	var someUUID *uuid.UUID
+	if err := DB.Table("users").Select("some_uuid").Scan(&someUUID).Error; err != nil {
+		t.Errorf("Failed, go error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -27,6 +28,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	SomeUUID  uuid.UUID
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

I want to be able to `Scan` into a pointer to a UUID so that I can nil-check the UUID after the query completes. This worked in v1.21.15 but this now panics in v1.23.8.
