### PR TITLE
Migrator sets incorrect alter table for float64

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/driver/sqlite"
 	"log"
 	"math/rand"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
-	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/jackc/pgx/v4 v4.17.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 // indirect
+	gorm.io/driver/mysql v1.3.6
+	gorm.io/driver/postgres v1.3.9
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,27 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+//TODO: Run migrations
+//Create a view
+//Re-Run Migrations and watch it fail boooooyaaaah
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
-
+	err := DB.Exec("create view test_view_1 as select * from users").Error
+	if err != nil {
+		t.Errorf("Failed to create a test view")
+	}
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	err = DB.AutoMigrate(&User{})
+	if err != nil {
+		t.Errorf("Migration fails")
+	}
+	err = DB.Exec("drop view test_view_1").Error
+	if err != nil {
+		t.Errorf("Failed to drop view")
 	}
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	TestValue float64
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

### Problem
I have a struct which migrates successfully the first time. (Must have some float64 value)
I then create a view involving the table.
Running a migration the second time with no changes to the struct results in a failure.

### Result:
```sql
ERROR: cannot alter type of a column used by a view or rule (SQLSTATE 0A000)
```

### Expected Result:

Should migrate with no error the second time given the struct was not modified in any way.


Dialects tested on:
`postgres`

I have only tested this with Postgres, I don't think it's an issue for other dialects

I think it's because the existing new column is a `numeric` and an alteration is being run to `decimal` which fails