### PR TITLE
bug: update sql does't return error: update xx set xx and xxx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mysql:
-    image: 'mysql:latest'
+    image: 'mysql:5.7'
     ports:
       - 9910:3306
     environment:

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -9,12 +10,25 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "test1", Age: 20}
 
 	DB.Create(&user)
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	updateName, updateAge := "test2", 22
+	err := DB.Exec("update users set name = ? and age = ? where id = ?", updateName, updateAge, user.ID).Error
+	if err == nil {
+		t.Error("Except err: Truncated incorrect DOUBLE value, but got nil")
+	}
+
+	var updatedUser User
+	if err := DB.First(&updatedUser, user.ID).Error; err != nil {
+		t.Errorf("Failed, got new user error: %v", err)
+	}
+	if reflect.DeepEqual(result, updatedUser) {
+		t.Errorf("Failed, update new user failed! old: %v, new: %v", result, updatedUser)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -18,17 +19,20 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
 	updateName, updateAge := "test2", 22
 	err := DB.Exec("update users set name = ? and age = ? where id = ?", updateName, updateAge, user.ID).Error
 	if err == nil {
-		t.Error("Except err: Truncated incorrect DOUBLE value, but got nil")
-	}
+		t.Error("expect err: Truncated incorrect DOUBLE value, but got nil")
 
-	var updatedUser User
-	if err := DB.First(&updatedUser, user.ID).Error; err != nil {
-		t.Errorf("Failed, got new user error: %v", err)
-	}
-	if reflect.DeepEqual(result, updatedUser) {
-		t.Errorf("Failed, update new user failed! old: %v, new: %v", result, updatedUser)
+		var updatedUser User
+		if err := DB.First(&updatedUser, user.ID).Error; err != nil {
+			t.Errorf("Failed, got new user error: %v", err)
+		}
+		if reflect.DeepEqual(result, updatedUser) {
+			t.Errorf("Failed, update new user failed! old: %v, new: %v", result, updatedUser)
+		}
+	} else {
+		fmt.Printf("got expect error: %v\n", err)
 	}
 }


### PR DESCRIPTION
## Update sql work fine: update xx set xx=b  and xxx=a where xx in mysql:5.7 instead of return an error

env:
mysql:5.7

sql:
```sql
update users set name = 'test2' and age = 22 where id = 1;
``` 
this sql return no error, and update success.
in mysql:
```
mysql> select * from users;
+----+-------------------------+-------------------------+------------+------+------+----------+------------+------------+--------+
| id | created_at              | updated_at              | deleted_at | name | age  | birthday | company_id | manager_id | active |
+----+-------------------------+-------------------------+------------+------+------+----------+------------+------------+--------+
|  1 | 2022-08-22 12:55:09.235 | 2022-08-22 12:55:09.235 | NULL       | 0    |   20 | NULL     |       NULL |       NULL |      0 |
+----+-------------------------+-------------------------+------------+------+------+----------+------------+------------+--------+
1 row in set (0.00 sec)
```

I have exec sql in mysql commandline client, it return an error:
```
mysql> update users set name = 'test2' and age = 22 where id = 1;
ERROR 1292 (22007): Truncated incorrect DOUBLE value: 'test2'
mysql>
```
You can use test code for reappear it.