### PR TITLE
clause.OnConflict generates column names even when OnConstraint is specified

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Thing{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: '3'
 
 services:
-  mysql:
-    image: 'mysql:latest'
-    ports:
-      - 9910:3306
-    environment:
-      - MYSQL_DATABASE=gorm
-      - MYSQL_USER=gorm
-      - MYSQL_PASSWORD=gorm
-      - MYSQL_RANDOM_ROOT_PASSWORD="yes"
+#  mysql:
+#    image: 'mysql:latest'
+#    ports:
+#      - 9910:3306
+#    environment:
+#      - MYSQL_DATABASE=gorm
+#      - MYSQL_USER=gorm
+#      - MYSQL_PASSWORD=gorm
+#      - MYSQL_RANDOM_ROOT_PASSWORD="yes"
   postgres:
     image: 'postgres:latest'
     ports:
@@ -19,14 +19,14 @@ services:
       - POSTGRES_DB=gorm
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
-  mssql:
-    image: 'mcmoe/mssqldocker:latest'
-    ports:
-      - 9930:1433
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=LoremIpsum86
-      - MSSQL_DB=gorm
-      - MSSQL_USER=gorm
-      - MSSQL_PASSWORD=LoremIpsum86
+#  mssql:
+#    image: 'mcmoe/mssqldocker:latest'
+#    ports:
+#      - 9930:1433
+#    environment:
+#      - ACCEPT_EULA=Y
+#      - SA_PASSWORD=LoremIpsum86
+#      - MSSQL_DB=gorm
+#      - MSSQL_USER=gorm
+#      - MSSQL_PASSWORD=LoremIpsum86
 

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ require (
 	gorm.io/gorm v1.23.4
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -58,3 +58,10 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Thing struct {
+	gorm.Model
+	SomeID  string `gorm:"index:,composite:something_idx"`
+	OtherID string `gorm:"index:,composite:something_idx"`
+	Data    string
+}


### PR DESCRIPTION
## Explain your user case and expected results
Use case: I want to bulk insert data with a ID primary key and two fields that represent a composite unique index. When I'm bulk creating, none of the records have IDs. If a record matches an existing composite index I want to update the fields, if it doesn't I want to insert a new row.

When defining the model I use `index:composite:something_idx` on the two fields. When using `clause.OnConflict` I specify that constraint:
```
result := DB.Clauses(clause.OnConflict{
	if err := DB.First(&result, user.ID).Error; err != nil {
		OnConstraint: "something_idx",
		UpdateAll:    true,
	})
```

The SQL generated has an error because it's adding the `id` column as the conflict target:
```sql
INSERT INTO "things" ("created_at","updated_at","deleted_at","some_id","other_id","data") VALUES ('2022-09-21 13:08:21.078','2022-09-21 13:08:21.078',NULL,'1234','1234','something else') 
ON CONFLICT ("id") ON CONSTRAINT something_idx
DO UPDATE SET "updated_at"='2022-09-21 13:08:21.078',"deleted_at"="excluded"."deleted_at","some_id"="excluded"."some_id","other_id"="excluded"."other_id","data"="excluded"."data"
RETURNING "id"
```

I get an error from Postgres:
```
ERROR: syntax error at or near "ON" (SQLSTATE 42601)
```
I expect the ON CONFLICT clause statement to be generated as:
```sql
ON CONFLICT ON CONSTRAINT something_idx
```