### PR TITLE
Gorm fills an embedded struct with Data from other entities instead of nil

### DIFF
--- a/db.go
+++ b/db.go
@@ -82,22 +82,18 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 }
 
 func RunMigrations() {
-	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
-	DB.Migrator().DropTable("user_friends", "user_speaks")
-
-	if err = DB.Migrator().DropTable(allModels...); err != nil {
-		log.Printf("Failed to drop table, got error %v\n", err)
-		os.Exit(1)
-	}
-
-	if err = DB.AutoMigrate(allModels...); err != nil {
-		log.Printf("Failed to auto migrate, but got error %v\n", err)
-		os.Exit(1)
-	}
+	DB.Exec(`DROP TABLE IF EXISTS "users";
+	create table "users"( 
+		id text,
+		revision int PRIMARY KEY ,
+		name text,
+		embed_field_name text
+	);
+`)
 
 	for _, m := range allModels {
 		if !DB.Migrator().HasTable(m) {

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,12 @@ go 1.16
 
 require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
+	github.com/stretchr/testify v1.8.0
 	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
+	gorm.io/driver/postgres v1.3.10
 	gorm.io/driver/sqlite v1.3.2
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.10
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -9,12 +11,64 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	testuser := []User{
+		{
+			ID:       "ID1",
+			Revision: 1,
+			Name:     "otherName",
+			Embed: &Embed{
+				FieldName: "Field",
+			},
+		},
+		{
+			ID:       "ID1",
+			Revision: 2,
+			Name:     "jinzhu",
+			Embed: &Embed{
+				FieldName: "Field",
+			},
+		},
+		{
+			ID:       "ID2",
+			Revision: 3,
+		},
+		{
+			ID:       "ID3",
+			Revision: 4,
+		},
+		{
+			ID:       "ID3",
+			Revision: 5,
+		},
 	}
+	for _, user := range testuser {
+		err := DB.Create(&user).Error
+		require.NoError(t, err)
+	}
+
+	users, err := getUsers([]string{"ID1", "ID3"})
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	if users[0].ID == testuser[0].ID {
+		assert.Equal(t, testuser[1], users[0])
+		assert.Equal(t, testuser[4], users[1])
+	} else {
+		assert.Equal(t, testuser[1], users[0])
+		assert.Equal(t, testuser[4], users[1])
+	}
+}
+
+func getUsers(userIDs []string) ([]User, error) {
+	var users []User
+	subquery := DB.
+		Select("MAX(revision) AS latest, id").
+		Group("id").
+		Where("users.id IN ?", userIDs).
+		Table("users")
+	err := DB.
+		Table("users").
+		Joins("RIGHT JOIN (?) AS r ON r.latest = users.revision", subquery).
+		Find(&users).
+		Error
+	return users, err
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,15 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	ID       string
+	Revision int `gorm:"primaryKey"`
+	Name     string
+	Embed    *Embed `gorm:"embedded;embeddedPrefix:embed_"`
 }
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Embed struct {
+	FieldName string
 }


### PR DESCRIPTION
We got an User struct with ID, a Revision, a name and one Embedded Struct, which is Referenced by a pointer
```
type User struct {
	ID       string
	Revision int `gorm:"primaryKey"`
	Name     string
	Embed    *Embed `gorm:"embedded;embeddedPrefix:embed_"`
}
type Embed struct {
	FieldName string
}
```
The goal is to get the newest Object (with the highest revision) for given userIDs
In SQL (PostgreSQL) this should look like this:
```
SELECT "users"."id", "users"."revision", "users"."name", "users"."embed_field_name"
FROM "users"
         RIGHT JOIN (SELECT MAX(revision) AS latest, id
                     FROM "users"
                     WHERE users.id IN <userIDs>
                     GROUP BY "id") AS r ON r.latest = users.revision
```
Gorm generates exactly that SQL Statement. So far, so good.

In the Testcase we Create 3 Users in our Database:
```
	testuser := []User{
		{
			ID:       "ID1",
			Revision: 1,
			Name:     "otherName",
			Embed: &Embed{
				FieldName: "Field",
			},
		},
		{
			ID:       "ID1",
			Revision: 2,
			Name:     "jinzhu",
			Embed: &Embed{
				FieldName: "Field",
			},
		},
		{
			ID:       "ID2",
			Revision: 3,
		},
	}
```
I expect to get the following Response after asking for the newest Users with IDs <ID1, ID2>:
```
{
	ID:       "ID1",
	Revision: 2,
	Name:     "jinzhu",
	Embed: &Embed{
		FieldName: "Field",
	},
},
{
	ID:       "ID2",
	Revision: 3,
}
```
The problem is that Gorm actually returns following:
```
		{
			ID:       "ID1",
			Revision: 2,
			Name:     "jinzhu",
			Embed: // Reference to 0xc00023cb30
		},
		{
			ID:       "ID2",
			Revision: 3,
			Name:     "",
			Embed: // Reference to 0xc00023cb30
		},
```
Both Embed points to the same Object, even if the SQL-Statement returns Embed of ID2 as nil