### PR TITLE
add reproducer for invalid loading of embedded fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
+	gorm.io/driver/mysql v1.3.6
+	gorm.io/driver/postgres v1.3.10
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.8
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -6,15 +6,33 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS:  postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		Name: "jinzhu",
+		Age:  1,
+	}
+	anotherUser := User{Name: "with-company", EmbeddedCompany: &Company{
+		ID:   2,
+		Name: "company",
+	}}
 
 	DB.Create(&user)
+	DB.Create(&anotherUser)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var result []User
+	err := DB.
+		Order("age DESC"). // make sure user with company is always loaded first
+		Find(&result).
+		Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	foundUser := result[0]
+
+	if foundUser.EmbeddedCompany != nil && foundUser.EmbeddedCompany.Name != "" {
+		t.Errorf("user jinzhu should not have embedded company: %+v", foundUser.EmbeddedCompany)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -11,12 +11,15 @@ import (
 func TestGORM(t *testing.T) {
 	user := User{
 		Name: "jinzhu",
-		Age:  1,
+		Age:  2,
 	}
-	anotherUser := User{Name: "with-company", EmbeddedCompany: &Company{
-		ID:   2,
-		Name: "company",
-	}}
+	anotherUser := User{
+		Name: "with-company",
+		Age:  1,
+		EmbeddedCompany: &Company{
+			ID:   2,
+			Name: "company",
+		}}
 
 	DB.Create(&user)
 	DB.Create(&anotherUser)
@@ -31,6 +34,10 @@ func TestGORM(t *testing.T) {
 	}
 
 	foundUser := result[0]
+
+	if foundUser.Name != "jinzhu" {
+		t.Errorf("jhinzu should be loaded first because of the order by age DESC clause")
+	}
 
 	if foundUser.EmbeddedCompany != nil && foundUser.EmbeddedCompany.Name != "" {
 		t.Errorf("user jinzhu should not have embedded company: %+v", foundUser.EmbeddedCompany)

--- a/models.go
+++ b/models.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"time"
 
 	"gorm.io/gorm"
 )
@@ -12,21 +11,10 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	ID              uint `gorm:"primarykey"`
+	Age             uint
+	Name            string
+	EmbeddedCompany *Company `gorm:"embedded;embeddedPrefix:company"`
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

I want to use the embedded flag to store some embedded data in the same table.

I expected only the user which has an embedded company to have an embedded company when loading it from the database together with other users.

It seems like that an user without an embedded company that is loaded after another user with an embedded company somehow gets the embedded company of the first user set instead of not having an embedded company.

This reproduces this bug: https://github.com/go-gorm/gorm/issues/5727