### PR TITLE
[repro] BeforeSave hook prevents legitimate updates when objects are not loaded

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
+	gorm.io/driver/mysql v1.3.6
+	gorm.io/driver/postgres v1.3.10
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.10
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,28 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestBeforeHookWorksWhenObjectIsLoaded(t *testing.T) {
+	company := Company{Name: "Gopherz"}
+
+	err := DB.Create(&company).Error
+	if err != nil {
+		t.Errorf("could not create new company: %v", err)
+	}
+
+	if err := DB.First(&Company{}, "id = ?", company.ID).Update("name", "Gophers").Error; err != nil {
+		t.Errorf("could not update company name: %v", err)
+	}
+}
+
+func TestBeforeSaveHookWithoutLoadingObject(t *testing.T) {
+	company := Company{Name: "Gopherz"}
+	err := DB.Create(&company).Error
+	if err != nil {
+		t.Errorf("could not create new company: %v", err)
+	}
+
+	if err := DB.Model(&Company{}).Where("id = ?", company.ID).Update("name", "Gophers"); err != nil {
+		t.Errorf("cannot update name to Gophers! %v", err)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
@@ -52,6 +53,13 @@ type Toy struct {
 type Company struct {
 	ID   int
 	Name string
+}
+
+func (c *Company) BeforeSave(tx *gorm.DB) (err error) {
+	if c.Name == "" {
+		err = errors.New("can't save company with blank name")
+	}
+	return
 }
 
 type Language struct {


### PR DESCRIPTION
This is an edge case that's surprising: `BeforeSave` hooks need the object loaded in memory to make updates to them. Otherwise their behavior is undefined.

In this repro I have a BeforeSave hook to check for empty names, but when I attempt to update an existing record with a non-empty name, the hook triggers regardless:
```
--- FAIL: TestBeforeSaveHookWithoutLoadingObject (0.00s)
    /Users/arnaud/git/playground/main_test.go:43: cannot update name to Gophers! &{0x140001e6240 can't save company with blank name 0 0x140004a81c0 0}
FAIL
```

I'd expect this update to succeed because it does not violate the hook. I get that it's tricky: `gorm` would have to load the object from the DB to run the hook. Another acceptable solution could be to disallow these types of updates entirely when hooks are defined, to minimize surprising behavior.
