### PR TITLE
Performing multiple migrations ends up in prepared statement cache error

### DIFF
--- a/db.go
+++ b/db.go
@@ -55,7 +55,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{PrepareStmt: true})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: '3'
 
 services:
-  mysql:
-    image: 'mysql:latest'
-    ports:
-      - 9910:3306
-    environment:
-      - MYSQL_DATABASE=gorm
-      - MYSQL_USER=gorm
-      - MYSQL_PASSWORD=gorm
-      - MYSQL_RANDOM_ROOT_PASSWORD="yes"
   postgres:
     image: 'postgres:latest'
     ports:
@@ -19,14 +10,3 @@ services:
       - POSTGRES_DB=gorm
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
-  mssql:
-    image: 'mcmoe/mssqldocker:latest'
-    ports:
-      - 9930:1433
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=LoremIpsum86
-      - MSSQL_DB=gorm
-      - MSSQL_USER=gorm
-      - MSSQL_PASSWORD=LoremIpsum86
-

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module gorm.io/playground
 go 1.16
 
 require (
+	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
-	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
-	gorm.io/driver/mysql v1.3.3
-	gorm.io/driver/postgres v1.3.5
-	gorm.io/driver/sqlite v1.3.2
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be // indirect
+	gorm.io/driver/mysql v1.3.6
+	gorm.io/driver/postgres v1.3.10
+	gorm.io/driver/sqlite v1.3.6
 	gorm.io/driver/sqlserver v1.3.2
-	gorm.io/gorm v1.23.4
+	gorm.io/gorm v1.23.10
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,58 @@
 package main
 
 import (
+	"fmt"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
+// GORM_BRANCH: v1.23.10
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+func migrateT1() error {
+	type MyTable struct {
+		gorm.Model
+		FieldOne string
+	}
 
-	DB.Create(&user)
+	return DB.AutoMigrate(&MyTable{})
+}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+func migrateT2() error {
+
+	type MyTable struct {
+		NewFieldTwo string
+	}
+
+	return DB.AutoMigrate(&MyTable{})
+}
+
+func migrateT3() error {
+	type MyTable struct {
+		NewFieldThree string
+	}
+	return DB.AutoMigrate(&MyTable{})
+}
+
+func TestGormMigrationWithPreparedStatements(t *testing.T) {
+	fmt.Println("Migrating T1")
+	err := migrateT1()
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	fmt.Println("Migrating T2")
+
+	err = migrateT2()
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	fmt.Println("Migrating T3")
+	err = migrateT3()
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
 }


### PR DESCRIPTION
When performing database migrations, when AutoMigrate is called multiple times to add new columns in a Table the following error is observed:

```
    main_test.go:55: Failed, got error: ERROR: cached plan must not change result type (SQLSTATE 0A000)
```

This was identified as part of an upgrade task we were working where we are trying to update from gorm.io/gorm v1.21.7 to v1.23.10.

The commit in this PR contain the needed changes to reproduce the issue. Modifications made:
* docker-compose file modified to only create postgresql
* the postgresql connection created in `db.go` is created with the `PrepareStmt: true` attribute for its gorm.Config
* The gorm.io/gorm dependency has been updated from v1.23.4 to v1.23.10. This has also indirectly updated other relevant dependencies like gorm.io/driver/postgres from v1.3.5 to v1.3.10 among other dependencies. go mod tidy has been applied after that too.
* The `GORM_BRANCH` statement in the `main_test.go` file has been modified from `master` to `v1.23.10`
* The `TestGORM` Go test has been removed from `main_test.go` as it is not needed to reproduce the issue
* The `TestGormMigrationWithPreparedStatements` test has been added. The test performs the following:
  1. Creates the `my_tables` table in the PostgreSQL db by using `DB.AutoMigrate` with a `MyTable` struct type defined for this PR containing some attributes (see call to `migrateT1`)
  2. Adds a new column in the `my_tables`  in the PostgreSQL db by using `DB.AutoMigrate`again with a redefined MyTable struct type containing a new field (see call to `migrateT2`)
  3. Adds a new column in the `my_tables` in the PostgreSQL db by using `DB.AutoMigrate` again with a redefined MyTable struct type containing a new field (see call to `migrateT3`)

To reproduce the issue run:
```
docker-compose up
```

and then:

```
GORM_DIALECT=postgres ./test.sh
```

The error shown at the beginning of this comment will be shown.

As explained, this issue was identified when we were migrating from gorm.io/gorm v1.21.7 to v1.23.10 in a project where we are using it. In v1.21.7 the reported issue does not seem to happen.