### PR TITLE
Field should be unique but is not

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,13 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/driver/sqlserver"
+	"gorm.io/gorm"
+	"gorm.io/gorm/migrator"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -17,4 +24,40 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+type UniqueTest struct {
+	UniqueIndex string `gorm:"size:191;uniqueIndex"`
+}
+
+func TestMigrateUnique(t *testing.T) {
+	err := DB.AutoMigrate(UniqueTest{})
+	if err != nil {
+		t.Errorf("AutoMigrate failed: %v", err)
+	}
+
+	var migrator migrator.Migrator
+	switch v := DB.Migrator().(type) {
+	case sqlite.Migrator:
+		migrator = v.Migrator
+	case mysql.Migrator:
+		migrator = v.Migrator
+	case postgres.Migrator:
+		migrator = v.Migrator
+	case sqlserver.Migrator:
+		migrator = v.Migrator
+	default:
+		t.Fatalf("unrecognized type: %T", v)
+	}
+
+	migrator.RunWithValue(&UniqueTest{}, func(stmt *gorm.Statement) (err error) {
+		field, ok := stmt.Schema.FieldsByDBName["unique_index"]
+		if !ok {
+			t.Errorf("unique_index not found")
+		} else if !field.Unique {
+			t.Errorf("expected field.unique to be true, got false: %+v", field)
+		}
+
+		return nil
+	})
 }


### PR DESCRIPTION
Model fields tagged with `uniqueIndex` are not recognized as unique.

## Explain your user case and expected results

Defining this model:
```go
type UniqueTest struct {
	UniqueIndex string `gorm:"size:191;uniqueIndex"`
}
```

... causes repeated invocations `DB.AutoMigrate(UniqueTest{})` to execute `ALTER COLUMN`, due to failing uniqueness check:
https://github.com/go-gorm/gorm/blob/2c56954cb12dd33fc8f1875a735091d61daff702/migrator/migrator.go#L464-L470

... presumably because the field does not have a `unique` tag:
https://github.com/go-gorm/gorm/blob/2c56954cb12dd33fc8f1875a735091d61daff702/schema/field.go#L116

Defining the model this way fixes the issue:
```go
type UniqueTest struct {
	UniqueIndex string `gorm:"size:191;unique;uniqueIndex"`
}
```