### PR TITLE
Issue migrating field with `CURRENT_TIMESTAMP`

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,14 @@ package main
 
 import (
 	"testing"
+	"time"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/driver/sqlserver"
+	"gorm.io/gorm"
+	"gorm.io/gorm/migrator"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -17,4 +25,40 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+type TimestampTest struct {
+	TimeAt *time.Time `gorm:"type:datetime;not null;default:CURRENT_TIMESTAMP"`
+}
+
+func TestMigrateTimestamp(t *testing.T) {
+	err := DB.AutoMigrate(TimestampTest{})
+	if err != nil {
+		t.Errorf("AutoMigrate failed: %v", err)
+	}
+
+	var migrator migrator.Migrator
+	switch v := DB.Migrator().(type) {
+	case sqlite.Migrator:
+		migrator = v.Migrator
+	case mysql.Migrator:
+		migrator = v.Migrator
+	case postgres.Migrator:
+		migrator = v.Migrator
+	case sqlserver.Migrator:
+		migrator = v.Migrator
+	default:
+		t.Fatalf("unrecognized type: %T", v)
+	}
+
+	migrator.RunWithValue(&TimestampTest{}, func(stmt *gorm.Statement) (err error) {
+		field, ok := stmt.Schema.FieldsByDBName["time_at"]
+		if !ok {
+			t.Errorf("time_at not found")
+		} else if field.DefaultValueInterface == nil {
+			t.Errorf("expected field.DefaultValueInterface to be non-nil: %+v", field)
+		}
+
+		return nil
+	})
 }


### PR DESCRIPTION
Tagging a field like this:
```go
TimeAt *time.Time `gorm:"type:datetime;not null;default:CURRENT_TIMESTAMP"`
```
...causes AutoMigrate to execute `ALTER TABLE` on each invocation. Due to `CURRENT_TIMESTAMP` not getting parsed here:
https://github.com/go-gorm/gorm/blob/2c56954cb12dd33fc8f1875a735091d61daff702/schema/field.go#L263-L267

This causes `AutoMigrate` to execute `ALTER TABLE` on these fields on every repeated invocation.

Relates to https://github.com/go-gorm/gorm/issues/5208

## Explain your user case and expected results

Defining a model with `default:CURRENT_TIMESTAMP`:

```go
type TimestampTest struct {
	TimeAt *time.Time `gorm:"type:datetime;not null;default:CURRENT_TIMESTAMP"`
}
```
... and then executing `AutoMigrate(&TimestampTest)`, should only cause `ALTER TABLE` to execute on the first invocation. Subsequent invocations should be no-ops. We run `AutoMigrate` on every deploy, and it takes up to 20 minutes on very large tables, due to this issue.

This is reproducible with `sqlite`, `mysql`, and `postgres`:
```bash
GORM_DIALECT=sqlite GORM_ENABLE_CACHE=true ./test.sh
GORM_DIALECT=mysql GORM_ENABLE_CACHE=true ./test.sh
GORM_DIALECT=postgres GORM_ENABLE_CACHE=true ./test.sh
```