### PR TITLE
mariadb insert returning started 10.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mysql:
-    image: 'mysql/mysql-server:latest'
+    image: 'mariadb:10.4'
     ports:
       - 9910:3306
     environment:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
+	golang.org/x/text v0.3.8 // indirect
 	gorm.io/driver/mysql v1.4.1
 	gorm.io/driver/postgres v1.4.4
 	gorm.io/driver/sqlite v1.4.2

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}


### PR DESCRIPTION
Found thanks to https://stackoverflow.com/questions/74090279/gorm-golang-create-does-not-work-getting-an-mariadb-error/74091326#74091326

`INSERT RETURNING` in mariadb began with version 10.5.0 (ref: https://mariadb.com/kb/en/insertreturning/).

`DELETE RETURNING` was added in 10.0.5 (https://jira.mariadb.org/browse/MDEV-3814).

There still isn't `UPDATE RETURNING` implemented.

```
2022/10/17 10:42:06 /home/dan/repos/playground/main_test.go:14 Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'RETURNING `id`' at line 1
[0.203ms] [rows:0] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`) VALUES ('2022-10-17 10:42:06.746','2022-10-17 10:42:06.746',NULL,'jinzhu',0,NULL,NULL,NULL,false) RETURNING `id`
```

There should be maybe a version dependent check on https://github.com/go-gorm/mysql/commit/ecb6c6a014f6fa2daa89e207f3e7d75f6c4b9f91#diff-1dcceb00f9e164c3494a982e1ed69ec5fd1506d1881b9cee030e9aee740cc378R120