### PR TITLE
reproduce nil dereference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	golang.org/x/crypto v0.1.0 // indirect
+	gorm.io/driver/mysql v1.4.3
+	gorm.io/driver/postgres v1.4.5
+	gorm.io/driver/sqlite v1.4.3
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,5 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	DB.Migrator().DropColumn("users", "age")
 }


### PR DESCRIPTION
## Explain your user case and expected results
When using `DropColumn`, the table cannot be provided as a string. Providing it as a model works fine. I expect it to work even when the table is provided as a string.