### PR TITLE
Race when concurrently appending m2m association when preloaded model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	golang.org/x/crypto v0.1.0 // indirect
+	gorm.io/driver/mysql v1.4.3
+	gorm.io/driver/postgres v1.4.5
+	gorm.io/driver/sqlite v1.4.3
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,17 @@
 package main
 
 import (
+	"log"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
+
+	"gorm.io/gorm/clause"
+)
+
+const (
+	count = 30
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +19,45 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	languages := []Language{}
+	for i := 0; i < count; i++ {
+		language := Language{Code: strconv.Itoa(i), Name: strconv.Itoa(i)}
+		DB.Create(&language)
+		languages = append(languages, language)
+	}
 
-	DB.Create(&user)
+	////////////////////////////////////////////////////////////////
+	// When this is deleted, the test passes also when preloading.
+	whenThisIsDeletedTheTestPasses := User{}
+	DB.Create(&whenThisIsDeletedTheTestPasses)
+	////////////////////////////////////////////////////////////////
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	user1 := User{}
+	if true { // If not preloading, the test passes.
+		DB.Preload(clause.Associations).First(&user1)
+	} else {
+		DB.First(&user1)
+	}
+
+	var wg sync.WaitGroup
+	for _, language := range languages {
+		wg.Add(1)
+		go func(userCopy User, languageCopy Language) {
+			defer wg.Done()
+			err := DB.Model(&userCopy).Association("Languages").Append(&languageCopy)
+			if err != nil {
+				log.Printf("[!] Error white appending post to user, %s", err)
+				return
+			}
+			time.Sleep(time.Second) // Simulating task.
+		}(user1, language)
+	}
+	wg.Wait()
+
+	user2 := User{}
+	DB.Preload(clause.Associations).First(&user2)
+	log.Println(len(user2.Languages) == count, len(user2.Languages))
+	if len(user2.Languages) != count {
+		t.Errorf("Failed, %d should be %d", len(user2.Languages), count)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -34,9 +34,9 @@ func TestGORM(t *testing.T) {
 
 	user1 := User{}
 	if true { // If not preloading, the test passes.
-		DB.Preload(clause.Associations).First(&user1)
+		DB.Preload(clause.Associations).FirstOrCreate(&user1)
 	} else {
-		DB.First(&user1)
+		DB.FirstOrCreate(&user1)
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Explain your user case and expected results
I tried appending to a m2m association inside a concurrent goroutines and for some reason it appended only some of the data.
While creating a minimal code example to test this i narrowed it down to this: 
- When the model is fetched from the db(previously created) & the associations are preloaded(Preload(clause.Associations)), it fails.
- If any of this changes the test passes(note the comments in the code)