### PR TITLE
FirstOrCreate is not thread safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,12 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	golang.org/x/crypto v0.1.0 // indirect
+	gorm.io/driver/mysql v1.4.3
+	gorm.io/driver/postgres v1.4.5
+	gorm.io/driver/sqlite v1.4.3
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755
 )
 
 replace gorm.io/gorm => ./gorm


### PR DESCRIPTION
## Explain your user case and expected results
Calling FirstOrCreate from multiple gouroutines for the same object results in a `UNIQUE constraint failed` error.

### Note
Maybe FirstOrCreate is not supposed to be safe by choice, i couldn't find any mention of that except this https://github.com/go-gorm/gorm/issues/2760, if it is by design maybe mention that in the documentation? i found in [v1 docs](https://v1.gorm.io/docs/method_chaining.html#Thread-Safety) that "GORM is safe for concurrent use by multiple goroutines."