### PR TITLE
AutoMigrate Belongs To Relationship always attempts to Alter table

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Company{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	golang.org/x/crypto v0.1.0 // indirect
+	gorm.io/driver/mysql v1.4.3
+	gorm.io/driver/postgres v1.4.5
+	gorm.io/driver/sqlite v1.4.3
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,8 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	comp := Company{Name: "comp"}
+	user := User{Name: "jinzhu", Company: comp}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
@@ -14,47 +11,11 @@ import (
 type User struct {
 	gorm.Model
 	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
+	CompanyID int
 	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
 }
 
 type Company struct {
 	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
 	Name string
 }


### PR DESCRIPTION
**DB: Postgres**

Observed that the following structs are translated to the table definitions as specified when run using gorm which is correct.

`
type Company struct {
	ID   int
	Name string
}
`

**Table Definition:** `CREATE TABLE "companies" ("id" bigserial,"name" text,PRIMARY KEY ("id"))`

`
type User struct {
	gorm.Model
	Name      string
	CompanyID int
	Company   Company
}
`
**Table Definition:** ` CREATE TABLE "users" ("id" bigserial,"created_at" timestamptz,"updated_at" timestamptz,"deleted_at" timestamptz,"name" text,"company_id" bigint,PRIMARY KEY ("id"),CONSTRAINT "fk_users_company" FOREIGN KEY ("company_id") REFERENCES "companies"("id"))`

I have got the tables created in Postgres DB successfully.

However, when we re-run the automigration on `User` struct again, gorm always attempt to run the following SQL:
`ALTER TABLE "users" ALTER COLUMN "company_id" TYPE bigint`

I run the auto-migration `n` times, this SQL gets executed `n` times. Observe a scenario where there are 15 structs referenced to one another then when the application runs the auto-migration there are so many Alter queries similar to this that run on DB and can clog the Database instance.
