### PR TITLE
bug: soft delete with table alias.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	golang.org/x/crypto v0.1.0 // indirect
+	gorm.io/driver/mysql v1.4.3
+	gorm.io/driver/postgres v1.4.5
+	gorm.io/driver/sqlite v1.4.3
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -9,12 +10,25 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
+	user := SoftDeleteUser{Name: "jinzhu"}
+	DB.AutoMigrate(SoftDeleteUser{})
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var results []SoftDeleteUser
+	// No error when table alias isn't used.
+	if err := DB.Table("soft_delete_users").Where("id = ?", 1).Find(&results).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	// Error occurs when table alias is used due to soft delete behavior using the name of the table as the alias on
+	// the soft delete column.
+	if err := DB.Table("soft_delete_users sds").Where("sds.id = ?", 1).Find(&results).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+type SoftDeleteUser struct {
+	gorm.Model
+	Name    string
+	Deleted gorm.DeletedAt
 }


### PR DESCRIPTION
Queries which use a table alias fail when the model defines a field of type gorm.DeleteAt for soft delete behavior.

## Explain your user case and expected results
