### PR TITLE
sqlite: new boolean colum on existing record not set to default value

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,16 +83,16 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
 	DB.Migrator().DropTable("user_friends", "user_speaks")
 
-	if err = DB.Migrator().DropTable(allModels...); err != nil {
-		log.Printf("Failed to drop table, got error %v\n", err)
-		os.Exit(1)
-	}
+	// if err = DB.Migrator().DropTable(allModels...); err != nil {
+	// 	log.Printf("Failed to drop table, got error %v\n", err)
+	// 	os.Exit(1)
+	// }
 
 	if err = DB.AutoMigrate(allModels...); err != nil {
 		log.Printf("Failed to auto migrate, but got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,17 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
+	github.com/jackc/pgtype v1.13.0 // indirect
+	github.com/jackc/pgx/v4 v4.17.2 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/microsoft/go-mssqldb v0.19.0 // indirect
+	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.5.0 // indirect
+	gorm.io/driver/mysql v1.4.5
+	gorm.io/driver/postgres v1.4.6
+	gorm.io/driver/sqlite v1.4.4
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.3
 )
 
 replace gorm.io/gorm => ./gorm

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gorm.io/playground
+module github.com/morremeyer/gorm-playground
 
 go 1.16
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +15,15 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var results []User
+	if err := DB.Where(&User{
+		Active: false,
+	}, "Active").Find(&results, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	// This must have 2 results since the first resource was created when the column did not exist yet
+	// I therefore assume that it should have the default value when using AutoMigrate.
+	// The second record is created when the column exits and therefore has the default value set.
+	assert.Len(t, results, 2)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
@@ -16,14 +16,10 @@ func TestGORM(t *testing.T) {
 	DB.Create(&user)
 
 	var results []User
-	if err := DB.Where(&User{
-		Active: false,
-	}, "Active").Find(&results, user.ID).Error; err != nil {
+	if err := DB.Find(&results, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 
-	// This must have 2 results since the first resource was created when the column did not exist yet
-	// I therefore assume that it should have the default value when using AutoMigrate.
-	// The second record is created when the column exits and therefore has the default value set.
-	assert.Len(t, results, 2)
+	// This must have 1 result since we have only created one resource.
+	assert.Len(t, results, 1)
 }

--- a/models.go
+++ b/models.go
@@ -4,12 +4,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name   string
-	Active bool
+	Name string
+	//Active bool
 }

--- a/models.go
+++ b/models.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
@@ -13,48 +10,6 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
 	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Active bool
 }


### PR DESCRIPTION
## Issue

When a new boolean colum is added, `AutoMigrate` does not set it to the default value for existing records.

## Expected result

I expect `AutoMigrate` to migrate this to the default value.

This has two reasons:

* Queries for that column will use `users.active = 1` or `users.active = 0`, where this record will not match none (see reproduction)
* A boolean in go can only be `true` or `false`. There is no way to use a struct query to find those fields, I would need to use an explicit query for `IS NULL` to get any of these rows back.

## Reproduction

Check out and run `test.sh`:

<details>
<summary>Log output for `./test.sh`</summary>

```
❯ ./test.sh
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
remote: Enumerating objects: 177, done.
remote: Counting objects: 100% (177/177), done.
remote: Compressing objects: 100% (170/170), done.
remote: Total 177 (delta 12), reused 43 (delta 5), pack-reused 0
Receiving objects: 100% (177/177), 207.34 KiB | 5.60 MiB/s, done.
Resolving deltas: 100% (12/12), done.
[+] Running 3/0
 ⠿ Container gorm-playground-mysql-1     Running                                                                                                                             0.0s
 ⠿ Container gorm-playground-postgres-1  Running                                                                                                                             0.0s
 ⠿ Container gorm-playground-mssql-1     Running                                                                                                                             0.0s
starting
testing sqlite...
2023/01/08 16:18:25 testing sqlite3...
=== RUN   TestGORM

2023/01/08 16:18:25 /Users/morre/repos/github.com/morremeyer/gorm-playground/main_test.go:16
[0.829ms] [rows:1] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`) VALUES ("2023-01-08 16:18:25.948","2023-01-08 16:18:25.948",NULL,"jinzhu") RETURNING `id`

2023/01/08 16:18:25 /Users/morre/repos/github.com/morremeyer/gorm-playground/main_test.go:19
[0.163ms] [rows:1] SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL
--- PASS: TestGORM (0.00s)
PASS
ok      github.com/morremeyer/gorm-playground   0.256s
skip mysql...
skip postgres...
skip sqlserver...
```
</details>

Then, run `git checkout d89f566bbe385a05b6e48a97c8d117790ea7eea1` to switch to the commit that adds the `Active bool` to the `User` model and tests that there are now two rows with the colum `active` set to `0`.

Run `GORM_ENABLE_CACHE=true ./test.sh` to perform the tests:

<details>
<summary>Log output for `GORM_ENABLE_CACHE=true ./test.sh`</summary>

```
❯ GORM_ENABLE_CACHE=true ./test.sh
[+] Running 3/0
 ⠿ Container gorm-playground-mssql-1     Running                                                                                                                             0.0s
 ⠿ Container gorm-playground-mysql-1     Running                                                                                                                             0.0s
 ⠿ Container gorm-playground-postgres-1  Running                                                                                                                             0.0s
starting
testing sqlite...
2023/01/08 16:18:42 testing sqlite3...
=== RUN   TestGORM

2023/01/08 16:18:42 /Users/morre/repos/github.com/morremeyer/gorm-playground/main_test.go:16
[1.965ms] [rows:1] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`active`) VALUES ("2023-01-08 16:18:42.41","2023-01-08 16:18:42.41",NULL,"jinzhu",false) RETURNING `id`

2023/01/08 16:18:42 /Users/morre/repos/github.com/morremeyer/gorm-playground/main_test.go:21
[0.164ms] [rows:1] SELECT * FROM `users` WHERE `users`.`active` = false AND `users`.`id` = 2 AND `users`.`deleted_at` IS NULL
    main_test.go:28: 
                Error Trace:    /Users/morre/repos/github.com/morremeyer/gorm-playground/main_test.go:28
                Error:          "[{{%!s(uint=2) 2023-01-08 16:18:42.410772 +0100 +0100 2023-01-08 16:18:42.410772 +0100 +0100 {0001-01-01 00:00:00 +0000 UTC %!s(bool=false)}} jinzhu %!s(bool=false)}]" should have 2 item(s), but has 1
                Test:           TestGORM
--- FAIL: TestGORM (0.00s)
FAIL
FAIL    gorm.io/playground      0.218s
FAIL
```
</details>

The database now contains two records: One that was created with the default value (ID 2), one that was created before the column existed and has no value (ID 1).

``` 
❯ sqlite3 /var/folders/mz/5b4wqvv90w5_qpjsprq86b7w0000gn/T/gorm.db
SQLite version 3.39.5 2022-10-14 20:58:05
Enter ".help" for usage hints.
sqlite> .headers on
sqlite> select * from users;
id|created_at|updated_at|deleted_at|name|active
1|2023-01-08 16:18:25.948829+01:00|2023-01-08 16:18:25.948829+01:00||jinzhu|
2|2023-01-08 16:18:42.410772+01:00|2023-01-08 16:18:42.410772+01:00||jinzhu|0
```

Now, open the test database on your machine with `sqlite3` directly. You need to know where your local temporary directory is, e.g. with `sqlite3 /var/folders/mz/5b4wqvv90w5_qpjsprq86b7w0000gn/T/gorm.db`

In the DB shell, run

```sql
.headers on
select * from users;
```

The first record is from the first test:

```
id|created_at|updated_at|deleted_at|name|active
1|2023-01-08 16:18:25.948829+01:00|2023-01-08 16:18:25.948829+01:00||jinzhu|
```

