### PR TITLE
AutoMigrate fail when using views or rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-## Explain your user case and expected results
+## Explain your use case and expected results

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgtype v1.13.0 // indirect
+	github.com/jackc/pgx/v4 v4.17.2 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.5.0 // indirect
+	gorm.io/driver/mysql v1.4.5
+	gorm.io/driver/postgres v1.4.6
+	gorm.io/driver/sqlite v1.4.4
+	gorm.io/driver/sqlserver v1.4.2
+	gorm.io/gorm v1.24.3
 )
 
-replace gorm.io/gorm => ./gorm
+replace gorm.io/gorm v1.24.3 => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -9,12 +11,38 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	require.NoError(t, DB.Exec(`DROP VIEW IF EXISTS first_foo`).Error)
+	require.NoError(t, DB.Exec(`DROP TABLE IF EXISTS foo`).Error)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	err := DB.AutoMigrate(&Foo1{})
+	require.NoError(t, err)
+
+	err = DB.Exec(`CREATE VIEW first_foo AS SELECT name FROM foo LIMIT 1`).Error
+	assert.NoError(t, err)
+
+	// Now migrate table by changing type of column
+	err = DB.AutoMigrate(&Foo2{})
+	assert.NoError(t, err)
+
+}
+
+type Foo1 struct {
+	ID   string
+	Name string
+	Age  int
+}
+
+type Foo2 struct {
+	ID   string
+	Name string `gorm:"type:varchar(255)"`
+	Age  int
+}
+
+func (Foo1) TableName() string {
+	return "foo"
+}
+
+func (Foo2) TableName() string {
+	return "foo"
 }


### PR DESCRIPTION
## Explain your user case and expected results

If views were created using columns of an existing table in a **Postgres** database, making modifications to the table causes `AutoMigrate` to fail.

