### PR TITLE
Multiple OnConflict clauses cannot be added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgtype v1.13.0 // indirect
+	github.com/jackc/pgx/v4 v4.17.2 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	golang.org/x/crypto v0.5.0 // indirect
+	gorm.io/driver/mysql v1.4.5
+	gorm.io/driver/postgres v1.4.6
+	gorm.io/driver/sqlite v1.4.4
+	gorm.io/driver/sqlserver v1.4.2
+	gorm.io/gorm v1.24.3
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -9,9 +10,25 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", Nickname: "jinzhu"}
+	user2 := User{Name: "john", Nickname: "jinzhu"} // this should fail
+	user3 := User{Name: "jane", Nickname: "jinzhu"} // this should fail too
 
 	DB.Create(&user)
+	if tx := DB.Create(&user2); tx.Error != nil && strings.Contains(tx.Error.Error(), "UNIQUE constraint failed") {
+		t.Log("Got the error", tx.Error) // as expected: UNIQUE constraint failed
+	} else {
+		t.Error("Did not get error with unique constraint", tx.Error)
+	}
+	BeforeCreate1 = true  // add first OnConflict clause for `nickname`
+	if tx := DB.Create(&user2); tx.Error != nil { // this should not fail
+		t.Error("Still got error", tx.Error)
+	}
+	BeforeCreate2 = true  // add second OnConflict clause for `id`
+	// (in fact it overwrites the first one, resulting in no OnConflict clauses for nickname
+	if tx := DB.Create(&user3); tx.Error != nil { // this should not fail
+		t.Errorf("Getting error because of overwritten clause: %v\nNotice the missing first ON CONFLICT clause in the query above!", tx.Error)
+	}
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {

--- a/models.go
+++ b/models.go
@@ -14,6 +14,7 @@ import (
 type User struct {
 	gorm.Model
 	Name      string
+	Nickname  string     `gorm:"uniqueIndex"`
 	Age       uint
 	Birthday  *time.Time
 	Account   Account

--- a/models.go
+++ b/models.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
@@ -28,6 +29,22 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+}
+var BeforeCreate1, BeforeCreate2 bool
+func (u *User) BeforeCreate(tx *gorm.DB) error {
+    if BeforeCreate1 {
+        tx.Statement.AddClause(clause.OnConflict{
+            Columns: []clause.Column{{Name: "nickname"}},
+            DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
+        })
+    }
+    if BeforeCreate2 {
+        tx.Statement.AddClause(clause.OnConflict{
+            Columns: []clause.Column{{Name: "id"}},
+            UpdateAll: true,
+        })
+    }
+    return nil
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

SQLite3 supports multiple ON CONFLICT clauses with different "conflict targets", but Gorm seems to not allow that.