### PR TITLE
Add TestCase for Automigrate on Postgres

### DIFF
--- a/automig/v1/request.go
+++ b/automig/v1/request.go
@@ -1,0 +1,10 @@
+package automigv1
+
+import "gorm.io/gorm"
+
+// Request is a test struct to validate automigration of indexes with Postgres.
+// In this first version, the Request model has a unique Index for Names
+type Request struct {
+	gorm.Model
+	Name string `json:"name" gorm:"unique"`
+}

--- a/automig/v2/request.go
+++ b/automig/v2/request.go
@@ -1,0 +1,12 @@
+package automigv2
+
+import "gorm.io/gorm"
+
+// Request is a test struct to validate automigration of indexes with Postgres.
+// In this second version, the Request modelthe unique index for name has been removed
+// So when migrating from Request.V1 to RequestV2 we should be able to add new entries
+// with the same name
+type Request struct {
+	gorm.Model
+	Name string `json:"name"`
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	automigv1 "gorm.io/playground/automig/v1"
+	automigv2 "gorm.io/playground/automig/v2"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -17,4 +20,36 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestAutoMigrate(t *testing.T) {
+	req1 := automigv1.Request{Name: "Request1"}
+	req2 := automigv1.Request{Name: "Request1"}
+
+	err := DB.AutoMigrate(automigv1.Request{})
+	if err != nil {
+		t.Fatalf("unable to automigrate to v1 %v", err)
+	}
+
+	err = DB.Create(&req1).Error
+	if err != nil {
+		t.Fatalf("At least first object should have been created: %v", err)
+	}
+	err = DB.Create(&req2).Error
+	if err == nil {
+		t.Fatalf("There should be an unique index violation on Name")
+	}
+
+	err = DB.AutoMigrate(automigv2.Request{})
+	// At this point the unique index on name should have been deleted
+	// and it should be possible to create the req2 object
+	if err != nil {
+		t.Fatalf("unable to automigrate to v2 %v", err)
+	}
+
+	err = DB.Create(&req2).Error
+	if err != nil {
+		t.Fatalf("req2 should be created after migrating to v2: %v", err)
+	}
+
 }


### PR DESCRIPTION
This testcase intends to depict a bug on Automigrate with postgres: When Migrating tables with a colume with a unique index to the same column WITHOUT the unique index we see the followig symptoms:

* The automigrate procedure does not fail
* Automigrae logs tries to CREATE the inde and logs a warning stating the index already exists
* When adding an entry to the table with a Name that already exists, there is a unique violation error

Signed-off-by: Oscar Moya <oscar.moya1@ibm.com>

## Explain your user case and expected results
