### PR TITLE
Preload relations inside embedded field

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,20 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	country := Country{Name: "TestCountry"}
 
+	DB.Create(&country)
+
+	user := User{Name: "jinzhu", WorkAddress: Address{CountryID: country.ID}, HomeAddress: Address{CountryID: country.ID}}
 	DB.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	DB.Preload(clause.Associations).First(&result)
+
+	if result.WorkAddress.Country != country {
+		t.Error("WorkAddress country has not been resolved")
+	}
+	if result.HomeAddress.Country != country {
+		t.Error("HomeAddress country has not been resolved")
 	}
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,9 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+
+	WorkAddress Address `gorm:"embedded;embeddedPrefix:work_address_"`
+	HomeAddress Address `gorm:"embedded;embeddedPrefix:home_address_"`
 }
 
 type Account struct {
@@ -56,5 +59,17 @@ type Company struct {
 
 type Language struct {
 	Code string `gorm:"primarykey"`
+	Name string
+}
+
+type Address struct {
+	City      string
+	Street    string
+	Country   Country
+	CountryID int
+}
+
+type Country struct {
+	ID   int
 	Name string
 }


### PR DESCRIPTION
I added HomeAddress and WorkAddress fields to the user, both of them are embedded fields of type Address. Address has a BelongsTo relation with a Country.

Now, when I try to Preload all associations on user. Only one of the Countries inside the addresses gets loaded, while the other stays empty.

I would like to be able to Preload both of the countries inside addresses