### PR TITLE
Add test code that demonstrates panic in Scope functions.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -13,8 +15,36 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// this works fine.
+	users := []User{}
+	company := Company{}
+
+	err := DB.Raw("select * from companies limit 1").Scan(&company).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %+v", err)
+	}
+
+	// this does not panic and works as expected.
+	err = DB.Raw("select * from users limit 2").Scan(&users).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %+v", err)
+	}
+
+	// this panics!
+	err = DB.Scopes(func(d *gorm.DB) *gorm.DB {
+		// If Block A is removed, the panic goes away.
+		//
+		// BLOCK A
+		a := Account{}
+		if err := d.Raw("select * from accounts limit 1").Scan(&a).Error; err != nil {
+			return d
+		}
+		// END BLOCK
+
+		return d.Raw("select * from users limit 2")
+	}).Scan(&users).Error
+
+	if err != nil {
+		t.Errorf("Failed, got error: %+v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
When using _Scopes_ function, if you use the `*gorm.DB`   instance to fetch something (I only used Raw here) and then again to return `Raw` it panics.

We use the following versions in our code base and the same code works without panicking, while trying to upgrade to gorm 1.24.5 we noticed this problem.

````
go: upgraded gorm.io/driver/mysql v1.0.3 => v1.4.3
go: upgraded gorm.io/gorm v1.20.12 => v1.24.5
go: upgraded gorm.io/plugin/dbresolver v1.1.0 => v1.4.1
````