### PR TITLE
Save does not save nested field as I expected

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,17 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.3.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/microsoft/go-mssqldb v0.20.0 // indirect
+	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.7.0 // indirect
+	gorm.io/driver/mysql v1.4.7
+	gorm.io/driver/postgres v1.5.0
+	gorm.io/driver/sqlite v1.4.4
+	gorm.io/driver/sqlserver v1.4.2
+	gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,39 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{
+		Model: gorm.Model{ID: 1},
+		Name:  "jinzhu",
+		Account: Account{
+			// UserID: 1,
+			Number: "myAccount",
+		},
+	}
 
-	DB.Create(&user)
+	// tx := DB
+	tx := DB.Begin()
+	defer tx.Rollback()
+	tx.Create(&user)
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := tx.Preload("Account").First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	result.Name = "Timothy"                  // This gets saved.
+	result.Account.Number = "My new account" // I expect this should be saved as well.
+
+	// I test on Postgres and this fails. The statement I see during save is
+	// INSERT INTO "accounts" ("created_at","updated_at","deleted_at","user_id","number","id") VALUES ('2023-03-17 14:06:38.363','2023-03-17 14:06:38.363',NULL,1,'My new account',1) ON CONFLICT ("id") DO UPDATE SET "user_id"="excluded"."user_id" RETURNING "id"
+	// And it's because ON CONFLICT DO UPDATE does not update the fields.
+	if err := tx.Save(&result).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	var result2 User
+	if err := tx.Preload("Account").First(&result2, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	assert.Equal(t, "My new account", result2.Account.Number) // fails
 }


### PR DESCRIPTION
## Explain your user case and expected results

I test on Postgres. Save nested data I see:

INSERT INTO "accounts" ("created_at","updated_at","deleted_at","user_id","number","id") VALUES ('2023-03-17 14:06:38.363','2023-03-17 14:06:38.363',NULL,1,'My new account',1) ON CONFLICT ("id") DO UPDATE SET "user_id"="excluded"."user_id" RETURNING "id"

And it's because ON CONFLICT DO UPDATE does not update the fields.
