### PR TITLE
RETURNING Clause uses wrong column

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,16 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.3.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/microsoft/go-mssqldb v0.20.0 // indirect
+	golang.org/x/crypto v0.7.0 // indirect
+	gorm.io/driver/mysql v1.4.7
+	gorm.io/driver/postgres v1.5.0
+	gorm.io/driver/sqlite v1.4.4
+	gorm.io/driver/sqlserver v1.4.2
+	gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,9 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	test := Test{Whatever: "asdsada"}
 
-	DB.Create(&user)
+	DB.AutoMigrate(&Test{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	DB.Create(&test)
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,8 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Test struct {
+	ID       int `gorm:"primaryKey,column:test_id"`
+	Whatever string
+}


### PR DESCRIPTION
## Explain your user case and expected results

Using a custom model where the primary key has a different name than the struct field name
```golang
type Test struct {
	ID       int `gorm:"primaryKey,column:test_id"`
	Whatever string
}
```

When doing a `Create()`, the query is as follows
```sql
-- Generated Query
INSERT INTO `tests` (`whatever`) VALUES ("asdsada") RETURNING `id`
-- Expected
INSERT INTO `tests` (`whatever`) VALUES ("asdsada") RETURNING `test_id`
```