### PR TITLE
gorm.io/driver/postgres v1.4.6 breaks enum values

### DIFF
--- a/db.go
+++ b/db.go
@@ -55,7 +55,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		dialector := postgres.New(postgres.Config{
+			DSN: "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+			PreferSimpleProtocol: true,
+		})
+		db, err = gorm.Open(dialector, &gorm.Config{})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,13 @@ require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
+	// This works:
+	// gorm.io/driver/postgres v1.4.5
+	// This doesn't:
+	gorm.io/driver/postgres v1.4.6
 	gorm.io/driver/sqlite v1.4.2
 	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	gorm.io/gorm v1.24.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,15 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	company := Company{
+		Name: "jinzhu",
+		MyEnum: Enum_ONE,
+	}
 
-	DB.Create(&user)
+	DB.Create(&company)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var result Company
+	if err := DB.First(&result, company.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -7,6 +7,24 @@ import (
 	"gorm.io/gorm"
 )
 
+type Enum int32
+
+const (
+	Enum_ONE = 1
+	Enum_TWO = 2
+)
+
+func (e Enum) String() string {
+	switch e {
+	case Enum_ONE:
+		return "ONE"
+	case Enum_TWO:
+		return "TWO"
+	default:
+		return "<unknown>"
+	}
+}
+
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
@@ -52,6 +70,7 @@ type Toy struct {
 type Company struct {
 	ID   int
 	Name string
+	MyEnum Enum
 }
 
 type Language struct {

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ fi
 
 [ -d gorm ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}'))
 
-go get -u -t ./...
+#go get -u -t ./...
 
 # SqlServer for Mac M1
 if [[ -z $GITHUB_ACTION ]]; then


### PR DESCRIPTION
## Explain your user case and expected results

This test fails after upgrading `gorm.io/driver/postgres` from v1.4.5 to v1.4.6

The test adds an enum type that contains a `String()` method

```
2023/03/24 14:56:40 testing postgres...
=== RUN   TestGORM

2023/03/24 14:56:40 /home/zchenyu/git8/playground/main_test.go:17 ERROR: invalid input syntax for type integer: "ONE" (SQLSTATE 22P02)
[1.317ms] [rows:0] INSERT INTO "companies" ("name","my_enum") VALUES ('jinzhu',1) RETURNING "id"

2023/03/24 14:56:40 /home/zchenyu/git8/playground/main_test.go:20 record not found
[0.721ms] [rows:0] SELECT * FROM "companies" WHERE "companies"."id" = 0 ORDER BY "companies"."id" LIMIT 1
    main_test.go:21: Failed, got error: record not found
```

Expected (with v1.4.5):

```
testing postgres...
2023/03/24 14:55:46 testing postgres...
=== RUN   TestGORM

2023/03/24 14:55:46 /home/zchenyu/git8/playground/main_test.go:17
[5.801ms] [rows:1] INSERT INTO "companies" ("name","my_enum") VALUES ('jinzhu',1) RETURNING "id"

2023/03/24 14:55:46 /home/zchenyu/git8/playground/main_test.go:20
[0.643ms] [rows:1] SELECT * FROM "companies" WHERE "companies"."id" = 1 ORDER BY "companies"."id" LIMIT 1
--- PASS: TestGORM (0.01s)
```