### PR TITLE
Repeatly creates unique indexes on the same field when `AutoMigrate`

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,16 @@ go 1.16
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.3.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/microsoft/go-mssqldb v0.21.0 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
+	gorm.io/driver/mysql v1.4.7
+	gorm.io/driver/postgres v1.5.0
+	gorm.io/driver/sqlite v1.4.4
+	gorm.io/driver/sqlserver v1.4.2
+	gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,35 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Index struct {
+	Table 		string
+	Key_name	string
+	Non_unique	uint
+	Column_name	string
+	Seq_in_index	uint
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	t.Logf("Running AutoMigrate multiple times...\n");
+	DB.AutoMigrate(&User{})
+	DB.AutoMigrate(&User{})
+	DB.AutoMigrate(&User{})
+	rows, err := DB.Raw("SHOW INDEX FROM users").Rows()
+	defer rows.Close()
+	if err != nil {
+		t.Fatalf("Failed on query, got error: %v", err)
+	}
+	var index Index
+	count := 0
+	for rows.Next() {
+		err = DB.ScanRows(rows, &index)
+		if err != nil {
+			t.Fatalf("Failed on scan, got error: %v", err)
+		}
+		t.Logf("index: %+v\n", index)
+		count += 1
+	}
+	if count != 1 {
+		t.Fatalf("Created multiple unique indexes on the same field when executing AutoMigrate, count: %v\n", count)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,8 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Name      string `gorm:"uniqueIndex;not null;default:"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

Model `User` has only one field `Name`, with `uniqueIndex` tag. First time I run `AutoMigrate`, GORM will create two unique indexes called `idx_users_name` and `name`. Then every time I run `AutoMigrate`, GORM will create a new unique index called `name_2`, `name_3` and so on.

If I use `uniqueIndex:i_u_name` to specify the name of the unique index, the first run would still create `i_u_name` and `name` indexes, and the following runs would still create `name_2`, `name_3` indexes.