### PR TITLE
Race condition in FirstOrCreate

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"gorm.io/gorm"
+	"sync"
 	"testing"
 )
 
@@ -8,13 +10,27 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+var wg sync.WaitGroup
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// Point ID to 1
+	model := gorm.Model{
+		ID: 1,
 	}
+
+	user := User{
+		Model: model,
+	}
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := DB.FirstOrCreate(&user).Error; err != nil {
+				t.Errorf("Failed, got error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,7 @@ var wg sync.WaitGroup
 
 func TestGORM(t *testing.T) {
 
+	tx := DB.Session(&gorm.Session{})
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
@@ -27,7 +28,7 @@ func TestGORM(t *testing.T) {
 			user := User{
 				Model: model,
 			}
-			if err := DB.FirstOrCreate(&user).Error; err != nil {
+			if err := tx.FirstOrCreate(&user).Error; err != nil {
 				t.Errorf("Failed, got error: %v", err)
 			}
 		}()

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ var wg sync.WaitGroup
 
 func TestGORM(t *testing.T) {
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/main_test.go
+++ b/main_test.go
@@ -13,19 +13,20 @@ import (
 var wg sync.WaitGroup
 
 func TestGORM(t *testing.T) {
-	// Point ID to 1
-	model := gorm.Model{
-		ID: 1,
-	}
 
-	user := User{
-		Model: model,
-	}
-
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+
+			// Point ID to 1
+			model := gorm.Model{
+				ID: 1,
+			}
+
+			user := User{
+				Model: model,
+			}
 			if err := DB.FirstOrCreate(&user).Error; err != nil {
 				t.Errorf("Failed, got error: %v", err)
 			}


### PR DESCRIPTION
## Explain your user case and expected results

I tried running FirstOrCreate in multiple threads and got the following error output:
```
2023/04/21 04:12:34 /Users/haozi/playground/main_test.go:30 UNIQUE constraint failed: users.id
[4.397ms] [rows:0] INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`,`id`) VALUES ("2023-04-21 04:12:34.393","2023-04-21 04:12:34.393",NULL,"",0,NULL,NULL,NULL,false,1) RETURNING `id`
    main_test.go:31: Failed, got error: UNIQUE constraint failed: users.id
```
It seems that FirstOrCreate's operation on the database is not atomic and not thread-safe.

**Expected: no errors and tests pass.**