### PR TITLE
BeforeSave is executed twice in a transaction

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Token{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.3.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
+	gorm.io/driver/mysql v1.5.0
+	gorm.io/driver/postgres v1.5.0
+	gorm.io/driver/sqlite v1.5.0
+	gorm.io/driver/sqlserver v1.4.3
+	gorm.io/gorm v1.25.0
 )
 
 replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -12,7 +12,9 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
+	// NOTE: If gorm.Model is used, tests will success
+	// gorm.Model
+	ID        uint `gorm:"primarykey"`
 	Name      string
 	Age       uint
 	Birthday  *time.Time
@@ -27,6 +29,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	Token     Token `gorm:"foreignkey:UserID"`
 }
 
 type Account struct {
@@ -57,4 +60,15 @@ type Company struct {
 type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
+}
+
+type Token struct {
+	UserID  uint `gorm:"primary_key"`
+	Content string
+}
+
+// This method should be called only once
+func (t *Token) BeforeSave(tx *gorm.DB) error {
+	t.Content += "_encrypted"
+	return nil
 }


### PR DESCRIPTION
## Explain your user case and expected results

When you save a model which BeforeSave is implemented in a transaction, BeforeSave will be executed twice.

## Conditon

- GORM v1.25.0
- mysql
- not using `gorm.Model`
- using `gorm:"foreignKey:UserID"`
- in a transaction

## Log

```bash
testing mysql...
2023/05/01 15:06:26 testing mysql...
=== RUN   TestGORM

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[2.665ms] [rows:1] INSERT INTO `tokens` (`content`,`user_id`) VALUES ('token_encrypted',1) ON DUPLICATE KEY UPDATE `content`=VALUES(`content`)

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[6.092ms] [rows:1] INSERT INTO `users` (`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`) VALUES ('user',0,NULL,NULL,NULL,false)

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:45
[1.486ms] [rows:1] SELECT * FROM `tokens` WHERE `tokens`.`user_id` = 1

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:45
[3.697ms] [rows:1] SELECT * FROM `users` WHERE `users`.`id` = 1 ORDER BY `users`.`id` LIMIT 1

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[1.410ms] [rows:2] INSERT INTO `tokens` (`content`,`user_id`) VALUES ('token2_encrypted',1) ON DUPLICATE KEY UPDATE `content`=VALUES(`content`)

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[3.431ms] [rows:0] UPDATE `users` SET `name`='user',`age`=0,`birthday`=NULL,`company_id`=NULL,`manager_id`=NULL,`active`=false WHERE `id` = 1

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[2.544ms] [rows:2] INSERT INTO `tokens` (`content`,`user_id`) VALUES ('token2_encrypted_encrypted',1) ON DUPLICATE KEY UPDATE `content`=VALUES(`content`)

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:41
[4.421ms] [rows:0] INSERT INTO `users` (`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`,`id`) VALUES ('user',0,NULL,NULL,NULL,false,1) ON DUPLICATE KEY UPDATE `name`=VALUES(`name`),`age`=VALUES(`age`),`birthday`=VALUES(`birthday`),`company_id`=VALUES(`company_id`),`manager_id`=VALUES(`manager_id`),`active`=VALUES(`active`)

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:45
[1.493ms] [rows:1] SELECT * FROM `tokens` WHERE `tokens`.`user_id` = 1

2023/05/01 15:06:27 /home/ras/ghq/github.com/ras0q/gorm-playground/main_test.go:45
[3.604ms] [rows:1] SELECT * FROM `users` WHERE `users`.`id` = 1 ORDER BY `users`.`id` LIMIT 1
    main_test.go:34: expected token2_encrypted, got token2_encrypted_encrypted
--- FAIL: TestGORM (0.04s)
FAIL
FAIL    gorm.io/playground      1.099s
FAIL
```