### PR TITLE
Add Test for Empty String

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,16 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,20 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type NullableStringType struct {
+	Value string `gorm:"default:null"`
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	DB.AutoMigrate(&NullableStringType{})
+	value := NullableStringType{Value: "jinzhu"}
+	value2 := NullableStringType{}
+	values := []NullableStringType{value, value2}
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	tx := DB.Create(&values)
+	if tx.Error != nil {
+		// Fails for sqlite - near "DEFAULT": syntax error
+		// [0.210ms] [rows:0] INSERT INTO `nullable_string_types` (`value`) VALUES ("jinzhu"),(DEFAULT) RETURNING `value`
+		t.Fail()
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
I expect this code to not fail when using sqlite. I would like to be able to use the native `string` type, but have gorm detect a zero-valued string (i.e., `""`), and insert it as `NULL` into the database instead of empty string. This behavior is specified in the documentation here:

<img width="798" alt="image" src="https://github.com/go-gorm/playground/assets/9583514/5dd32ddb-c1b0-4c40-9e61-4f468378d318">
