### PR TITLE
test: demo model with "default:null" fields are not set in read

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,26 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	// first, demonstrate that the email address is empty in the db.
+	if result.EmailNoDefault != "" {
+		t.Errorf("expected email to be empty but got: %s", result.Email)
+	}
+	if result.Email != "" {
+		t.Errorf("expected email to be empty but got: %s", result.Email)
+	}
+
+	// now, we'll set it to a value before reading it from the db.
+	result.Email = "jinzhu@example.com"
+	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	// shouldn't the email address be empty after the read, since it's not set
+	// in the db?
+	if result.EmailNoDefault != "" {
+		t.Errorf("expected email to be empty but got: %s", result.Email)
+	}
+	if result.Email != "" {
+		t.Errorf("expected email to be empty but got: %s", result.Email)
+	}
+
 }

--- a/models.go
+++ b/models.go
@@ -13,20 +13,25 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	Name     string
+	Age      uint
+	Birthday *time.Time
+	// Email has a default null value... which appears to be what keeps it from
+	// being properly set when reading the value from the db... but the inbound
+	// dest has Email set.
+	Email          string `gorm:"default:null"`
+	EmailNoDefault string
+	Account        Account
+	Pets           []*Pet
+	Toys           []Toy `gorm:"polymorphic:Owner"`
+	CompanyID      *int
+	Company        Company
+	ManagerID      *uint
+	Manager        *User
+	Team           []User     `gorm:"foreignkey:ManagerID"`
+	Languages      []Language `gorm:"many2many:UserSpeak"`
+	Friends        []*User    `gorm:"many2many:user_friends"`
+	Active         bool
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

We recently updated our gorm dependency and we had some regression tests fail.  During our investigation we discovered that when the there's a gorm tag of `default:null` the value from the database is not set in the returned resource.

We would expect that anytime a resource is read that it's value should match the values in the database, regardless of any gorm tags.