### PR TITLE
minimal changes to mimic many2many doc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/microsoft/go-mssqldb v1.0.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,34 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	err := DB.Model(&result).Association("Languages").Append(&Language{
+		Code: "en-us",
+		Name: "English",
+	})
+	if err != nil {
+		t.Errorf("Association Append Failed, got error: %v", err)
+	}
+
+	user2 := User{Name: "diligiant"}
+
+	DB.Create(&user2)
+
+	var result2 User
+	if err := DB.First(&result2, user2.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	err = DB.Model(&result2).Association("Languages").Append(&Language{
+		Code: "en-us",
+		Name: "English",
+	})
+	if err != nil {
+		t.Errorf("Association Append Failed, got error: %v", err)
+	}
+
+	var languages []Language
+	if err := DB.Find(&languages).Error; err != nil {
+		t.Errorf("Finding languages Failed, got error: %v", err)
+	}
 }

--- a/models.go
+++ b/models.go
@@ -55,6 +55,7 @@ type Company struct {
 }
 
 type Language struct {
-	Code string `gorm:"primarykey"`
+	gorm.Model
+	Code string `gorm:"size:64;uniqueIndex"`
 	Name string
 }


### PR DESCRIPTION
(also here: https://stackoverflow.com/questions/76358210/how-to-make-the-many2many-gorm-documentation-example-work)

I tried to reproduce the documentation [first many2many example](https://gorm.io/docs/many_to_many.html#Many-To-Many) with no success in this playground.

```
type User struct {
  gorm.Model
  Languages []Language `gorm:"many2many:user_languages;"`
}

type Language struct {
  gorm.Model
  Name string
}
```

I would have expected to end up with 2 join tables entries pointing to the same Language but it does not (tested with postgres, mysql & sqlite). Details are in the stackoverflow question (I can copy/paste if that's more convenient).