### PR TITLE
Automigrate creating different uniqueIndexes on subsequent runs

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,16 +83,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
 	DB.Migrator().DropTable("user_friends", "user_speaks")
-
-	if err = DB.Migrator().DropTable(allModels...); err != nil {
-		log.Printf("Failed to drop table, got error %v\n", err)
-		os.Exit(1)
-	}
 
 	if err = DB.AutoMigrate(allModels...); err != nil {
 		log.Printf("Failed to auto migrate, but got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/microsoft/go-mssqldb v1.1.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,23 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	db := DB
 
-	DB.Create(&user)
+	user1 := User{Name: "jinzhu"}
+	db.Create(&user1)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	user2 := User{Name: "bob", Description: "hello"}
+	db.Create(&user2)
+
+	db.Delete(&user2)
+
+	user3 := User{Name: "joe", Description: "hello"}
+	db.Create(&user3)
+
+	user4 := User{Name: "peter", Description: "hello"}
+	err := db.Create(&user4).Error
+	if err == nil {
+		t.Error("expected duplicate key error")
 	}
+
 }

--- a/models.go
+++ b/models.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
@@ -13,48 +10,6 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Name        string `gorm:"type:varchar(64);uniqueIndex:user_name"`
+	Description string `gorm:"type:varchar(64);uniqueIndex:user_description_exclude_deleted,where:deleted_at IS NULL;not null"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

I have an existing database and consistently run `Automigrate` but after upgrading my gorm version from 1.28.3, the automigrate is creating different unique indexes than the ones I have defined and already exist in my database.

To reproduce, pull this branch and run `GORM_DIALECT=postgres go test`. This should work and pass tests. But if you run it again, it will fail to make migrations because it is trying to create a uniqueIndex and uniqueConstraint that doesn't have the same `name` or `where` clause as the unique index that I defined:
`ERROR: could not create unique index "idx_users_description" (SQLSTATE 23505)`

After the initial run of `AutoMigrate` the unique indexes that I defined are correctly created:
<img width="500" alt="image" src="https://github.com/go-gorm/playground/assets/60052974/c2c1b06a-119d-4940-9fe3-345a0403bd23">

But after the next time I run `AutoMigrate`, it created new unique indexes with a different name and without the where clause:
<img width="500" alt="image" src="https://github.com/go-gorm/playground/assets/60052974/b58cf2b0-c873-4fc2-a0ab-ac2fc8e19538">

I can only get to the state of the second picture if I don't have any data that conflicts the `where` clause of the unique index of the `description` column. In my use case, I have a table with a unique index with a `where deleted_at is NULL` condition but now that my `AutoMigrate` behaves differently, I cannot run migrations.

Did something change with how `AutoMigrate` handles unique indexes?
