### PR TITLE
GORM can't convert a model to VALUES sql when calling db.Create from a nested gin handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,16 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/gin-gonic/gin v1.9.1
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/microsoft/go-mssqldb v1.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,61 @@
 package main
 
 import (
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+func errHandler1(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		m := User{Name: "thing"}
+		errHandler2(db, m)(c)
 	}
+}
+
+func errHandler2(db *gorm.DB, model interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := db.Create(&model).Error; err != nil {
+			log.Fatalln("db.Create error:", err)
+			c.JSON(http.StatusInternalServerError, nil)
+			return
+		}
+		c.JSON(http.StatusOK, nil)
+	}
+}
+
+func noErrHandler(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		model := User{Name: "thing"}
+		if err := db.Create(&model).Error; err != nil {
+			log.Fatalln("db.Create error:", err)
+			c.JSON(http.StatusInternalServerError, nil)
+			return
+		}
+		c.JSON(http.StatusOK, nil)
+	}
+}
+
+func TestGORM(t *testing.T) {
+	r := gin.Default()
+	r.GET("/1", noErrHandler(DB))
+	r.GET("/2", errHandler1(DB))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/1", nil)
+	r.ServeHTTP(w, req)
+	log.Println("Req 1 status:", w.Result().StatusCode)
+
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/2", nil)
+	r.ServeHTTP(w2, req2)
+	log.Println("Req 2 status:", w.Result().StatusCode)
 }


### PR DESCRIPTION
## Explain your user case and expected results
Description
Calling DB.Create(&model) in a nested gin handler results in incorrectly formatted SQL which causes failure.
Eg. m := User{Name: "dan"} results in INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`age`,`birthday`,`company_id`,`manager_id`,`active`) VALUES  (no values present).