### PR TITLE
fix arm64 sqlcmd installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ gorm
 go.sum
 .*
 *.db
+go-sqlcmd
+sqlcmd


### PR DESCRIPTION
## Explain your user case and expected results
Fixes https://github.com/go-gorm/playground/issues/611
This checks if sqlcmd is in $PATH and if not, clones and builds the repo locally then sets a temporary alias for sqlcmd.
Tested on a 2023 MBP M2.