### PR TITLE
demonstrate table alias behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/microsoft/go-mssqldb v1.1.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,36 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 )
+
+// Mock out the only relevant part of the dialector
+type QuoteDialector struct {}
+func (_ *QuoteDialector) Name() string { return "" }
+func (_ *QuoteDialector) Initialize(_ *gorm.DB) error { return nil }
+func (_ *QuoteDialector) Migrator(_ *gorm.DB) gorm.Migrator { return nil }
+func (_ *QuoteDialector) DataTypeOf(_ *schema.Field) string { return "" }
+func (_ *QuoteDialector) DefaultValueOf(_ *schema.Field) clause.Expression { return nil }
+func (_ *QuoteDialector) BindVarTo(_ clause.Writer, _ *gorm.Statement, _ interface{}) {}
+func (_ *QuoteDialector) QuoteTo(w clause.Writer, s string) {
+	w.WriteString("\"")
+	w.WriteString(s)
+	w.WriteString("\"")
+}
+func (_ *QuoteDialector) Explain(sql string, vars ...interface{}) string { return "" }
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	stmt := &gorm.Statement{DB: &gorm.DB{Config: &gorm.Config{Dialector: &QuoteDialector{}}}}
+	stmt.QuoteTo(&stmt.SQL, clause.Table{Name: "table", Alias: "alias"})
+	expected := `"table" AS "alias"`
+	if stmt.SQL.String() != expected {
+		t.Errorf("Failed, generated SQL is not equal, expects `%v`, but got `%v`", expected, stmt.SQL.String())
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

I would like table aliases to function. Specifically, I want to use `db.Clauses(clause.Insert{Table: clause.Table{Name: "Users", Alias: "u"}}).Create(&User{})` and have the resulting SQL statement insert the `AS` keyword between the table name and the alias in the resulting SQL so that I can use that alias in a later `clause.OnConflict` with a `DoUpdates` field, for example:

```go
db.Clauses(
    clause.Insert{Table: clause.Table{Name: "Users", Alias: "u"}},
    clause.OnConflict{
        Where: clause.Where{
            Exprs: []clause.Expression{
                clause.And(
                    gorm.Expr(`u.name <> ?`, user.name),
                    gorm.Expr(`u.name NOT LIKE CONCAT( ?, " AKA %")`, user.name),
                    gorm.Expr(`u.name NOT LIKE CONCAT( "% AKA ", ?)`, user.name),
                    gorm.Expr(`u.name NOT LIKE CONCAT("% AKA ", ? " AKA %")`, user.name),
                ),
            },
        },
        DoUpdates: clause.Assignments(map[string]any{
          "name": gorm.Expr(`CONCAT(u.name, " AKA ", ?)`, user.name),
        }),
    },
).Create(user)
```

Note that I NEED to be able to specify the table alias (or table name) for this query because in postgres, at least, the row that failed to insert is also available and so the identifier `name` is ambiguous (see the `conflict_action` heading on the [postgres `INSERT` docs](https://www.postgresql.org/docs/current/sql-insert.html#id-1.9.3.152.6.3.3) for more explanation).