### PR TITLE
Master many2many automigrate

### DIFF
--- a/db.go
+++ b/db.go
@@ -51,6 +51,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		}
 		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{
 			DisableForeignKeyConstraintWhenMigrating: true,
+			// IgnoreRelationshipsWhenMigrating: true, // TODO 默认应该启用这个功能
 			Logger: logger.New(log.New(os.Stdout, "\r\n", log.LstdFlags), logger.Config{
 				Colorful:                  false,
 				LogLevel:                  logger.Info,

--- a/db.go
+++ b/db.go
@@ -49,7 +49,14 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 		}
-		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+			Logger: logger.New(log.New(os.Stdout, "\r\n", log.LstdFlags), logger.Config{
+				Colorful:                  false,
+				LogLevel:                  logger.Info,
+				IgnoreRecordNotFoundError: true,
+			}),
+		})
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,22 +10,22 @@ services:
       - MYSQL_USER=gorm
       - MYSQL_PASSWORD=gorm
       - MYSQL_RANDOM_ROOT_PASSWORD="yes"
-  postgres:
-    image: 'postgres:latest'
-    ports:
-      - 9920:5432
-    environment:
-      - TZ=Asia/Shanghai
-      - POSTGRES_DB=gorm
-      - POSTGRES_USER=gorm
-      - POSTGRES_PASSWORD=gorm
-  mssql:
-    image: '${MSSQL_IMAGE:-mcmoe/mssqldocker}:latest'
-    ports:
-      - 9930:1433
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=LoremIpsum86
-      - MSSQL_DB=gorm
-      - MSSQL_USER=gorm
-      - MSSQL_PASSWORD=LoremIpsum86
+#  postgres:
+#    image: 'postgres:latest'
+#    ports:
+#      - 9920:5432
+#    environment:
+#      - TZ=Asia/Shanghai
+#      - POSTGRES_DB=gorm
+#      - POSTGRES_USER=gorm
+#      - POSTGRES_PASSWORD=gorm
+#  mssql:
+#    image: '${MSSQL_IMAGE:-mcmoe/mssqldocker}:latest'
+#    ports:
+#      - 9930:1433
+#    environment:
+#      - ACCEPT_EULA=Y
+#      - SA_PASSWORD=LoremIpsum86
+#      - MSSQL_DB=gorm
+#      - MSSQL_USER=gorm
+#      - MSSQL_PASSWORD=LoremIpsum86

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/microsoft/go-mssqldb v1.1.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.1
+	gorm.io/driver/sqlserver v1.5.0
+	gorm.io/gorm v1.25.1
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestGORM(t *testing.T) {
 	// user := User{Name: "jinzhu"}
-	// 使用many2many创建关联表后,又再次AutoMigrate创建关联表,因为之前创建了联合索引(primary key (user_id, friend_id)),导致关系表无法增加新的逐渐索引.
+	// 使用many2many创建关联表后,又再次AutoMigrate创建关联表,因为之前创建了联合索引(primary key (user_id, friend_id)),导致关系表无法增加新的主键索引(id).
+	// 当项目复杂,涉及很多表时,研发人员不容易关注到这个问题。
+	// 期望的解决方案:默认应该设置IgnoreRelationshipsWhenMigrating=true,来规避此问题?
 	err := DB.AutoMigrate(&User{}, &UserFriend{})
 	failOnError(t, err)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,15 +6,24 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// user := User{Name: "jinzhu"}
+	// 使用many2many创建关联表后,又再次AutoMigrate创建关联表,因为之前创建了联合索引(primary key (user_id, friend_id)),导致关系表无法增加新的逐渐索引.
+	err := DB.AutoMigrate(&User{}, &UserFriend{})
+	failOnError(t, err)
+}
 
-	DB.Create(&user)
+type UserFriend struct {
+	ID       uint64 `gorm:"primary_key"`
+	UserID   uint64 `gorm:"not null"`
+	FriendID uint64 `gorm:"not null"`
+}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+func failOnError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
`err := DB.AutoMigrate(&User{}, &UserFriend{})`
当开发者对gorm的AutoMigrate和many2many标签了解不深入时，容易像我上面那样使用AutoMigrate。
当gorm使用默认配置时(IgnoreRelationshipsWhenMigrating=false)，开发者可能容易忽略many2many会创建关联表，同时还会给表创建唯一的联合索引。
这样关系表就无法新增一个id主键索引了。
你觉得应该如何改善这个问题?