### PR TITLE
default issue(maybe)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+	github.com/stretchr/testify v1.8.0
 	gorm.io/driver/mysql v1.4.1
 	gorm.io/driver/postgres v1.4.4
 	gorm.io/driver/sqlite v1.4.2

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,36 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	err := DB.AutoMigrate(&Policy{})
+	assert.Nil(t, err)
 
-	DB.Create(&user)
+	// Create a new policy with all default settings
+	policy1 := Policy{Name: "policy10"}
+	result1 := DB.Create(&policy1)
+	assert.Nil(t, result1.Error)
+	assert.NotZero(t, policy1.ID)
+	assert.False(t, policy1.BoolFalse)
+	assert.True(t, policy1.BoolTrue)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	policy2 := Policy{Name: "policy20", BoolFalse: true, BoolTrue: false}
+	result2 := DB.Create(&policy2)
+	assert.Nil(t, result2.Error)
+	assert.NotZero(t, policy2.ID)
+	assert.True(t, policy2.BoolFalse)
+	assert.False(t, policy2.BoolTrue) // NOT RIGHT HERE
+
+	// Save
+	policy3 := Policy{Name: "policy30"}
+	result3 := DB.Save(&policy3)
+	assert.Nil(t, result3.Error)
+	assert.NotZero(t, policy3.ID)
+	assert.False(t, policy3.BoolFalse)
+	assert.True(t, policy3.BoolTrue)
+
+	policy4 := Policy{Name: "policy40", BoolFalse: true, BoolTrue: false}
+	result4 := DB.Save(&policy4)
+	assert.Nil(t, result4.Error)
+	assert.NotZero(t, policy4.ID)
+	assert.True(t, policy4.BoolFalse)
+	assert.False(t, policy4.BoolTrue) // NOT RIGHT HERE
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,10 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Policy struct {
+	gorm.Model
+	Name      string
+	BoolFalse bool `gorm:"default:false"`
+	BoolTrue  bool `gorm:"default:true"`
+}


### PR DESCRIPTION
According to the model with default bool, it's not desired. Is this a bug?

```go
type Policy struct {
	gorm.Model
	Name      string
	BoolFalse bool `gorm:"default:false"`
	BoolTrue  bool `gorm:"default:true"`
}
```

```go
policy2 := Policy{Name: "policy20", BoolFalse: true, BoolTrue: false}
result2 := DB.Create(&policy2)
assert.False(t, policy2.BoolTrue) // NOT RIGHT HERE
```

