### PR TITLE
Jsonb field of association isn't properly saved if it has default specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.4.0 // indirect
+	golang.org/x/crypto v0.10.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.2
+	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/gorm v1.25.2-0.20230530020048-26663ab9bf55
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -16,5 +17,62 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.AutoMigrate(Value{}); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.AutoMigrate(ValueDep{}); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// save predefined value to db
+	value := Value{}
+	if err := DB.Save(&value).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	valueDep := ValueDep{ValueID: value.ID, Name: "some-name", Params: Params{"foo": "bar"}}
+	if err := DB.Save(&valueDep).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// ensure that we can read it
+	var value2 Value
+	if err := DB.Preload("Deps").First(&value2, value.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// ensure that the name in db is some-name
+	if value2.Deps[0].Name != "some-name" {
+		t.Error("Failed to read predefined name value")
+	}
+
+	// ensure that the params in db has foo:bar
+	if value2.Deps[0].Params["foo"] != "bar" {
+		t.Error("Failed to read predefined foo value")
+	}
+
+	// update name, foo and save it to db
+	value2.Deps[0].Name = "new-name"
+	value2.Deps[0].Params["foo"] = "new-bar"
+	if err := DB.Session(&gorm.Session{FullSaveAssociations: true}).Save(value2).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// read again, expect updated values
+	var value3 Value
+	if err := DB.Preload("Deps").First(&value3, value.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// ensure simple string was updated
+	if value3.Deps[0].Name != "new-name" {
+		t.Errorf("Failed to save name, current state is: %v", value3.Deps[0].Name)
+	}
+
+	// see that jsonb params wasn't updated
+	if value3.Deps[0].Params["foo"] != "new-bar" {
+		t.Errorf("Failed to save params, current state is: %v", value3.Deps[0].Params)
 	}
 }


### PR DESCRIPTION
In this scenario we're trying to save a struct with an association which include jsonb field.

While trying to do it gorm is generating a request similar to this:
```
INSERT INTO "value_deps" ("created_at","updated_at","deleted_at","value_id","name","params","id") VALUES ('2023-06-16 20:10:28.427','2023-06-16 20:10:28.444',NULL,11,'new-name','{"foo":"new-bar"}',11) ON CONFLICT ("id") DO UPDATE SET "updated_at"='2023-06-16 20:10:28.444',"deleted_at"="excluded"."deleted_at","value_id"="excluded"."value_id","name"="excluded"."name" RETURNING "id","params","id"
```

Notice, that the SET clause doesn't have `params`, so in the case of conflict the params will not be updated.

Confusingly enough this bug happens only when the Params field has a default option. If we remove it, then the sql request will be ok
```
INSERT INTO "value_deps" ("created_at","updated_at","deleted_at","value_id","name","params","id") VALUES ('2023-06-16 20:15:27.645','2023-06-16 20:15:27.66',NULL,12,'new-name','{"foo":"new-bar"}',12) ON CONFLICT ("id") DO UPDATE SET "updated_at"='2023-06-16 20:15:27.66',"deleted_at"="excluded"."deleted_at","value_id"="excluded"."value_id","name"="excluded"."name","params"="excluded"."params" RETURNING "id","id"
```