### PR TITLE
Migrate docker-compose to v2

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,14 +14,14 @@ go get -u -t ./...
 # SqlServer for Mac M1
 if [[ -z $GITHUB_ACTION ]]; then
   if [[ $(uname -a) == *" arm64" ]]; then
-    MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker-compose up --detach --quiet-pull || true
+    MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker compose up --detach --quiet-pull || true
     echo "starting"
     go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" > /dev/null || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" > /dev/null || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" > /dev/null || true
   else
-    docker-compose up --detach --quiet-pull
+    docker compose up --detach --quiet-pull
     echo "starting..."
   fi
 fi


### PR DESCRIPTION
## Explain your user case and expected results

When running `./test.sh` I get this warning indicating that the docker compose command we're using is not going to be supported starting June 23:
```
❯ ./test.sh
...
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
```

The [migration guide](https://docs.docker.com/compose/migrate/) mentions that in most cases we only need to replace `docker-compose` with `docker compose`, which seems to be the case in playground.
