### PR TITLE
many2many fails when id=0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,17 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.4.1 // indirect
+	golang.org/x/crypto v0.10.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.2
+	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/gorm v1.25.2-0.20230530020048-26663ab9bf55
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,104 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	initDB(t)
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	expectedBars := map[int]int{
+		0: 2,
+		1: 3,
 	}
+
+	for fooID, expectedBarCount := range expectedBars {
+		var foo Foo
+		tx := DB.
+			Preload("Bars").
+			Where("foo_id = ?", fooID).
+			Find(&foo)
+
+		if err := tx.Error; err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
+
+		println("- foo", foo.FooID, foo.Value)
+		for _, bar := range foo.Bars {
+			println("  * bar", bar.BarID, bar.Value)
+		}
+
+		if len(foo.Bars) != expectedBarCount {
+			t.Errorf("Failed for FooID=%d, expected %d bars, but got %d", fooID, expectedBarCount, len(foo.Bars))
+		}
+	}
+
+}
+
+func initDB(t *testing.T) {
+	dbExec(t, "DROP TABLE IF EXISTS foo_bar")
+	dbExec(t, "DROP TABLE IF EXISTS foo")
+	dbExec(t, "DROP TABLE IF EXISTS bar")
+
+	dbExec(t, `
+		CREATE TABLE foo (
+			foo_id INTEGER NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (foo_id)
+		)
+	`)
+	dbExec(t, `
+		CREATE TABLE bar (
+			bar_id INTEGER NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (bar_id)
+		)
+	`)
+	dbExec(t, `
+		CREATE TABLE foo_bar (
+			foo_id INTEGER NOT NULL REFERENCES foo(foo_id),
+			bar_id INTEGER NOT NULL REFERENCES bar(bar_id),
+			PRIMARY KEY (foo_id, bar_id)
+		)
+	`)
+
+	// foos
+	dbExec(t, "INSERT INTO foo (foo_id, value) VALUES (0, 'foo0')")
+	dbExec(t, "INSERT INTO foo (foo_id, value) VALUES (1, 'foo1')")
+
+	// bars
+	dbExec(t, "INSERT INTO bar (bar_id, value) VALUES (0, 'bar0')")
+	dbExec(t, "INSERT INTO bar (bar_id, value) VALUES (1, 'bar1')")
+	dbExec(t, "INSERT INTO bar (bar_id, value) VALUES (2, 'bar2')")
+
+	// foo0 has 2 bars
+	dbExec(t, "INSERT INTO foo_bar (foo_id, bar_id) VALUES (0, 0)")
+	dbExec(t, "INSERT INTO foo_bar (foo_id, bar_id) VALUES (0, 1)")
+
+	// foo1 has 3 bars
+	dbExec(t, "INSERT INTO foo_bar (foo_id, bar_id) VALUES (1, 0)")
+	dbExec(t, "INSERT INTO foo_bar (foo_id, bar_id) VALUES (1, 1)")
+	dbExec(t, "INSERT INTO foo_bar (foo_id, bar_id) VALUES (1, 2)")
+}
+
+func dbExec(t *testing.T, sql string) {
+	if err := DB.Exec(sql).Error; err != nil {
+		t.Errorf("Failed exec sql, got error: %v", err)
+	}
+}
+
+type Foo struct {
+	FooID uint32 `gorm:"column:foo_id;autoIncrement:false"`
+	Value string `gorm:"column:value"`
+
+	Bars []*Bar `gorm:"many2many:foo_bar;joinReferences:bar_id;joinForeignKey:foo_id;references:bar_id;foreignKey:foo_id"`
+}
+
+func (Foo) TableName() string {
+	return "foo"
+}
+
+type Bar struct {
+	BarID uint32 `gorm:"column:bar_id;autoIncrement:false"`
+	Value string `gorm:"column:value"`
+}
+
+func (Bar) TableName() string {
+	return "bar"
 }


### PR DESCRIPTION
## Explain your user case and expected results

Here is a many2many table relationship between 2 entities `foo` & `bar`:

| foo_id | bar_id |
|--------|--------|
| 0 | 0 |
| 0 | 1 |
| 1 | 0 | 
| 1 | 1 |
| 1 | 2 |

When I fetch the `Foo` entity & Preload all its `Bar`, the relationship is broken when `foo_id=0` or `bar_id=0`

expected:
- foo 0 has 2 bars
- foo 1 has 3 bars

actual result:
- foo 0 has 0 bar
- foo 1 has 2 bars

```
--- FAIL: TestGORM (0.02s)
    main_test.go:36: Failed for FooID=0, expected 2 bars, but got 0
    main_test.go:36: Failed for FooID=1, expected 3 bars, but got 2
```

tested with `GORM_DIALECT=postgres`