### PR TITLE
Unnecessary SELECT query when preloading a has-many association

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,60 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	type Skill struct {
+		gorm.Model
+		ManagerID uint
+		Name      string
+	}
 
-	DB.Create(&user)
+	type Manager struct {
+		gorm.Model
+		Name   string
+		Skills []Skill
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	type Project struct {
+		gorm.Model
+		Name      string
+		ManagerID uint
+		Manager   Manager
+	}
+
+	if err := DB.Migrator().DropTable(
+		&Skill{}, &Manager{}, &Project{},
+	); err != nil {
+		panic(err)
+	}
+	if err := DB.AutoMigrate(
+		&Skill{}, &Manager{}, &Project{},
+	); err != nil {
+		t.Errorf("AutoMigrate failed: %v", err)
+	}
+
+	project := Project{
+		Name: "foo project",
+		Manager: Manager{
+			Name: "foo manager",
+			Skills: []Skill{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+				{
+					Name: "baz",
+				},
+			},
+		},
+	}
+	DB.Create(&project)
+
+	var result Project
+	if err := DB.
+		Joins("Manager").
+		Preload("Manager.Skills").
+		First(&result, project.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

This example shows that GORM makes an unnecessary `SELECT` to load an has-many association. It's unnecessary because the data has already been gathered by the `LEFT JOIN` clause.

```sql
[23.941ms] [rows:3] SELECT * FROM "skills" WHERE "skills"."manager_id" = 1 AND "skills"."deleted_at" IS NULL

-- This is the unnecessary query
[27.942ms] [rows:1] SELECT * FROM "managers" WHERE "managers"."id" = 1 AND "managers"."deleted_at" IS NULL

-- The LEFT JOIN below loads the Manager ID but GORM doesn't use it to load the Manager.Skills association
[55.694ms] [rows:1] SELECT "projects"."id","projects"."created_at","projects"."updated_at","projects"."deleted_at","projects"."name","projects"."manager_id","Manager"."id" AS "Manager__id","Manager"."created_at" AS "Manager__created_at","Manager"."updated_at" AS "Manager__updated_at","Manager"."deleted_at" AS "Manager__deleted_at","Manager"."name" AS "Manager__name" 
FROM "projects"
LEFT JOIN "managers" "Manager" ON "projects"."manager_id" = "Manager"."id" AND "Manager"."deleted_at" IS NULL 
WHERE "projects"."id" = 1 AND "projects"."deleted_at" IS NULL ORDER BY "projects"."id" OFFSET 0 ROW FETCH NEXT 1 ROWS ONLY
```