### PR TITLE
Ptw/recreate bug

### DIFF
--- a/db.go
+++ b/db.go
@@ -84,21 +84,15 @@ func RunMigrations() {
 		log.Print("failed to drop tables", err)
 		os.Exit(1)
 	}
-	// run Address migration
-	err := DB.Migrator().AutoMigrate(&Address{})
-	if err != nil {
-		log.Printf("Failed to migrate address, got %v", err)
-		os.Exit(1)
-	}
-	// Run User migration
-	err = DB.Migrator().AutoMigrate(&User{})
-	if err != nil {
-		log.Print("failed to migrate user", err)
-		os.Exit(1)
-	}
 	// run Address2 migration
 	if err := DB.Migrator().AutoMigrate(&Address2{}); err != nil {
 		log.Print("failed to migrate address 2: ", err)
+		os.Exit(1)
+	}
+	// Run User migration
+	err := DB.Migrator().AutoMigrate(&User{})
+	if err != nil {
+		log.Print("failed to migrate user", err)
 		os.Exit(1)
 	}
 	// check new address2 fields are there

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,56 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "narHash": "sha256-eKJDKTzI/uHNmfOX1Ln7Y1cjyA9XAkf5vyWdz03EXAA=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/55070e598e0e03d1d116c49b9eff322ef07c6ac6.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/55070e598e0e03d1d116c49b9eff322ef07c6ac6.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs = {
+    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/55070e598e0e03d1d116c49b9eff322ef07c6ac6.tar.gz";
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShell = with pkgs; mkShell {
+          buildInputs = [
+            go
+            gopls
+          ];
+        };
+      });
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,18 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.4.1 // indirect
+	github.com/microsoft/go-mssqldb v1.3.0 // indirect
+	golang.org/x/crypto v0.11.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.2
+	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/gorm v1.25.2
 )
 
 replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -1,60 +1,35 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
+type Address struct {
+	gorm.Model
+	UserId uint
+}
+
+func (Address) TableName() string {
+	return "addresses"
+}
+
+// Represents the edited address that has a uniqueness constraint
+// so that no user has more than one address
+type Address2 struct {
+	gorm.Model
+	UserId      uint `gorm:"uniqueIndex:,where: deleted_at is null"`
+	SecondField string
+}
+
+func (Address2) TableName() string {
+	return "addresses"
+}
+
+// User has one address.
+// Represent this same user with two structs to mock running a database migration
+// multiple times.
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+	Name    string
+	Address Address `gorm:"foreignKey:user_id"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

I'm using gorm to manage my database migrations. I have a foreign key field that initially had no restrictions but now I want to make sure that all of the non-deleted rows have unique field values. Depending on the initial state of the database (whether it already has this field or not, or whether it's a blank slate), there is either the non-deleted constraint added or not. This is specifically for postgres.

Running on 825968835191eb7d1c2f1fb7d26bddb6cfbbf09f, expected behavior.
```
❯ GORM_DIALECT=postgres ./test.sh
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
...
starting...
testing postgres...
2023/07/13 20:40:04 testing postgres...
=== RUN   TestGORM

2023/07/13 20:40:04 /Users/preston/git/gorm-playground/main_test.go:14
[5.349ms] [rows:1] INSERT INTO "users" ("created_at","updated_at","deleted_at","name") VALUES ('2023-07-13 20:40:04.126','2023-07-13 20:40:04.126',NULL,'jinzhu') RETURNING "id"

2023/07/13 20:40:04 /Users/preston/git/gorm-playground/main_test.go:17
[2.092ms] [rows:1] SELECT * FROM "users" WHERE "users"."id" = 1 AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1
--- PASS: TestGORM (0.01s)
PASS
ok      gorm.io/playground      0.314s
```

Describing the migrated table:
```
gorm=# \d addresses;
                                        Table "public.addresses"
    Column    |           Type           | Collation | Nullable |                Default
--------------+--------------------------+-----------+----------+---------------------------------------
 id           | bigint                   |           | not null | nextval('addresses_id_seq'::regclass)
 created_at   | timestamp with time zone |           |          |
 updated_at   | timestamp with time zone |           |          |
 deleted_at   | timestamp with time zone |           |          |
 user_id      | bigint                   |           |          |
 second_field | text                     |           |          |
Indexes:
    "addresses_pkey" PRIMARY KEY, btree (id)
    "idx_addresses_deleted_at" btree (deleted_at)
    "idx_addresses_user_id" UNIQUE, btree (user_id) WHERE deleted_at IS NULL
```

The `"idx_addresses_user_id" UNIQUE, btree (user_id) WHERE deleted_at IS NULL` is the important bit.

In contrast, checking out c05d2938533e78b91a1bfaa8dfb64fc10315dc45 (which first migrates without the constraint then migrates again to have the constraint) results in:
```
❯ git checkout c05d2938533e78b91a1bfaa8dfb64fc10315dc45

HEAD is now at c05d293 Update models and test

❯ GORM_DIALECT=postgres ./test.sh
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
...
starting...
testing postgres...
2023/07/13 20:51:13 testing postgres...
2023/07/13 20:51:14 found that user id was unique, which doesn't match what we saw before
FAIL    gorm.io/playground      0.358s
FAIL
```

Describing the table **does not have** the constraint that we want, leading to failures to migrate.
```
gorm=# \d addresses;
                                        Table "public.addresses"
    Column    |           Type           | Collation | Nullable |                Default
--------------+--------------------------+-----------+----------+---------------------------------------
 id           | bigint                   |           | not null | nextval('addresses_id_seq'::regclass)
 created_at   | timestamp with time zone |           |          |
 updated_at   | timestamp with time zone |           |          |
 deleted_at   | timestamp with time zone |           |          |
 user_id      | bigint                   |           |          |
 second_field | text                     |           |          |
Indexes:
    "addresses_pkey" PRIMARY KEY, btree (id)
    "idx_addresses_deleted_at" btree (deleted_at)
    "idx_addresses_user_id" UNIQUE CONSTRAINT, btree (user_id)
Foreign-key constraints:
    "fk_users_address" FOREIGN KEY (user_id) REFERENCES users(id)
```

Notice that the `WHERE deleted_at IS NULL` is missing.