### PR TITLE
case: many2many does not support non primaryKey

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	gorm.io/driver/mysql v1.4.1
 	gorm.io/driver/postgres v1.4.4
 	gorm.io/driver/sqlite v1.4.2

--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,32 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+// doc: https://gorm.io/docs/many_to_many.html#Override-Foreign-Key
+type Companny struct {
+	ID   int    `gorm:"primarykey"`
+	Name string `gorm:"index:,unique"`
+	Stus []Stu  `gorm:"many2many:stu_compannys;foreignKey:Name;joinForeignKey:CompannyName;References:Stuname;joinReferences:Stuname;"`
+}
+type Stu struct {
+	ID        int       `gorm:"primarykey"`
+	Stuname   string    `gorm:"index:,unique"`
+	Compannies []Companny `gorm:"many2many:stu_compannys;"`
+}
 
-	DB.Create(&user)
+func TestMany2ManyUniqueKey(t *testing.T) {
+    db := DB
+    db.Debug().Migrator().DropTable(&Companny{}, &Stu{}, "stu_compannys")
+	db.Debug().AutoMigrate(&Stu{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	err := db.Debug().Create(&Stu{
+		Stuname: "Alex3",
+		ID:      3,
+		Compannies: []Companny{
+			{Name: "PKU1"}, {Name: "TSU2"},
+		},
+	})
+	if err!=nil{
+		t.Fatal(err)
 	}
+
 }


### PR DESCRIPTION
## Explain your user case and expected results
I find that many2many does not support Non-PrimaryKey.(This is an error)

Reproduced steps:
```
GORM_DIALECT=postgres go test -v
```

```
[1.567ms] [rows:0] CREATE TABLE "stu_compannys" ("companny_name" text,"stuname" text,PRIMARY KEY ("companny_name","stuname"),CONSTRAINT "fk_stu_compannys_companny" FOREIGN KEY ("companny_name") REFERENCES "compannies"("name"),CONSTRAINT "fk_stu_compannys_stu" FOREIGN KEY ("stuname") REFERENCES "stus"("stuname"))

main_test.go:28 ERROR: column "stu_id" of relation "stu_compannys" does not exist (SQLSTATE 42703)
```



