### PR TITLE
Reproduction 'go/build import error when using ApplyInterface'

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,12 +4,10 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
-	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -68,8 +66,8 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		}
 		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
 	default:
-		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		log.Fatal("not supported dialect")
+		// db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,19 @@ module gorm.io/playground
 go 1.16
 
 require (
-	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/microsoft/go-mssqldb v1.5.0 // indirect
+	golang.org/x/tools v0.12.0 // indirect
+	gorm.io/datatypes v1.2.0 // indirect
+	gorm.io/driver/mysql v1.5.1
+	gorm.io/driver/postgres v1.5.2
+	gorm.io/driver/sqlite v1.5.3 // indirect
+	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/gen v0.3.23
+	gorm.io/gorm v1.25.2
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.4.6 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,27 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gen"
+	"gorm.io/playground/query"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+func TestGORM_GEN(t *testing.T) {
+	config := gen.Config{
+		OutPath:          "./query",
+		FieldWithTypeTag: true,
+		FieldNullable:    true,
+		Mode:             gen.WithDefaultQuery | gen.WithQueryInterface,
 	}
+	g := gen.NewGenerator(config)
+	g.UseDB(DB)
+	g.ApplyInterface(
+		func(query.CustomQuery) {},
+		g.GenerateModel("users"),
+	)
+	g.Execute()
 }

--- a/query/custom.go
+++ b/query/custom.go
@@ -1,0 +1,8 @@
+package query
+
+import "gorm.io/gen"
+
+type CustomQuery interface {
+	// SELECT * FROM @@table OFFSET 0 LIMIT 1
+	List() (*gen.T, error)
+}

--- a/test.sh
+++ b/test.sh
@@ -32,7 +32,13 @@ for dialect in "${dialects[@]}" ; do
     if [[ $(grep TEST_DRIVER main_test.go) =~ "${dialect}" ]]
     then
       echo "testing ${dialect}..."
-      GORM_DIALECT=${dialect} go test -race -count=1 -v ./...
+      GOOS=linux GOARCM=amd64 CGO_ENABLED=0 go test -o ./generate -c ./
+      docker run --rm\
+        --add-host host.docker.internal:host-gateway\
+        -e GORM_DSN="gorm:gorm@tcp(host.docker.internal:9910)/gorm?charset=utf8&parseTime=True&loc=Local"\
+        -e GORM_DIALECT=mysql\
+        -v "$(pwd)":/playground golang\
+        /playground/generate -test.v
     else
       echo "skip ${dialect}..."
     fi


### PR DESCRIPTION
## Explain your user case and expected results

### Test Case

Use gorm/gen generate query code, using `ApplyInterface`, the generate script is built in the host machine but running in a docker container.

### Expected

Generate code success.

### Actual

```console
[error] get interface name or file fail: go/build: go list gorm.io/playground/query: fork/exec /Users/bytedance/sdk/go1.19.5/bin/go: no such file or directory
```