### PR TITLE
AutoMigrate keeps receating tables if model has unique composite indexes

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,32 @@
 package main
 
 import (
+	"log"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
-// GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+type M struct {
+	ID uint64 `gorm:"primarykey"`
+	I  string `gorm:"uniqueIndex:idx_name"`
+	I2 string `gorm:"uniqueIndex:idx_name"`
+}
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+func Test(t *testing.T) {
+	r := require.New(t)
+	db, err := gorm.Open(sqlite.Open("test.sqlite3?_journal=WAL"), &gorm.Config{
+		Logger: logger.New(
+			log.New(os.Stdout, "\r\n", log.LstdFlags),
+			logger.Config{
+				LogLevel: logger.Info,
+			},
+		),
+	})
+	r.NoError(err)
+	db.AutoMigrate(&M{})
 }


### PR DESCRIPTION
## Explain your user case and expected results

这是一个极简复现。

test 不会 failed。但可以从 log 中看出表被重建了多次。

```txt
2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:-] SELECT count(*) FROM sqlite_master WHERE type='table' AND name="ms"

2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:2] SELECT sql FROM sqlite_master WHERE type IN ("table","index") AND tbl_name = "ms" AND sql IS NOT NULL order by type = "table" desc

2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:-] SELECT * FROM `ms` LIMIT 1

2023/08/23 19:34:30 main_test.go:31
[0.554ms] [rows:1] PRAGMA foreign_keys

2023/08/23 19:34:30 
[0.000ms] [rows:-] SELECT sql FROM sqlite_master WHERE type = "table" AND tbl_name = "ms" AND name = "ms"

2023/08/23 19:34:30 
[0.590ms] [rows:0] CREATE TABLE `ms__temp` (`id` integer,`i` text,`i2` text,PRIMARY KEY (`id`))

2023/08/23 19:34:30 
[0.000ms] [rows:0] INSERT INTO `ms__temp`(`id`,`i`,`i2`) SELECT `id`,`i`,`i2` FROM `ms`

2023/08/23 19:34:30 
[0.610ms] [rows:0] DROP TABLE `ms`

2023/08/23 19:34:30 
[2.264ms] [rows:0] ALTER TABLE `ms__temp` RENAME TO `ms`

2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:1] PRAGMA foreign_keys

2023/08/23 19:34:30 
[0.000ms] [rows:-] SELECT sql FROM sqlite_master WHERE type = "table" AND tbl_name = "ms" AND name = "ms"

2023/08/23 19:34:30 
[0.000ms] [rows:0] CREATE TABLE `ms__temp` (`id` integer,`i` text,`i2` text,PRIMARY KEY (`id`))

2023/08/23 19:34:30 
[0.000ms] [rows:0] INSERT INTO `ms__temp`(`id`,`i`,`i2`) SELECT `id`,`i`,`i2` FROM `ms`

2023/08/23 19:34:30 
[0.539ms] [rows:0] DROP TABLE `ms`

2023/08/23 19:34:30 
[1.057ms] [rows:0] ALTER TABLE `ms__temp` RENAME TO `ms`

2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:-] SELECT count(*) FROM sqlite_master WHERE type = "index" AND tbl_name = "ms" AND name = "idx_name"

2023/08/23 19:34:30 main_test.go:31
[0.000ms] [rows:0] CREATE UNIQUE INDEX `idx_name` ON `ms`(`i`,`i2`)
PASS
Process 23596 has exited with status 0
Detaching
dlv dap (26924) exited with code: 0

```
