### PR TITLE
Add issue reproduction of contant recreation

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,14 @@ func TestGORM(t *testing.T) {
 
 	DB.Create(&user)
 
+	if err := DB.AutoMigrate(Toy{}); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.AutoMigrate(Toy{}); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)

--- a/models.go
+++ b/models.go
@@ -44,7 +44,7 @@ type Pet struct {
 
 type Toy struct {
 	gorm.Model
-	Name      string
+	Name      string `gorm:"type:varchar;default:''"`
 	OwnerID   string
 	OwnerType string
 }


### PR DESCRIPTION
## Explain your user case and expected results
When we have a gorm object with a varchar colum and a '' default value, gorm constantly tries to alter the tabl, even though the default value is already set currectly. This causes an issue we cannot avoid since we write our migrations to migrations files and not automatically execute them. 

You can see this by typing 
```
$ GORM_DIALECT=postgres ./test.sh| grep ALTER                                                                                                           
Cloning into 'gorm'...
remote: Enumerating objects: 179, done.
remote: Counting objects: 100% (179/179), done.
remote: Compressing objects: 100% (172/172), done.
remote: Total 179 (delta 11), reused 62 (delta 5), pack-reused 0
Receiving objects: 100% (179/179), 222.93 KiB | 1.16 MiB/s, done.
Resolving deltas: 100% (11/11), done.
playground_mssql_1 is up-to-date
playground_mysql_1 is up-to-date
playground_postgres_1 is up-to-date
package github.com/microsoft/go-sqlcmd/cmd/sqlcmd is not a main package
[2.034ms] [rows:0] ALTER TABLE "toys" ALTER COLUMN "name" SET DEFAULT ''
[1.616ms] [rows:0] ALTER TABLE "toys" ALTER COLUMN "name" SET DEFAULT ''
```

- This started happening on upgrade from 
```
gorm.io/driver/postgres v1.2.3
gorm.io/gorm v1.22.5
```
to
```
gorm.io/driver/postgres v1.5.2
gorm.io/gorm v1.25.2
```


