### PR TITLE
Update test to trigger panic

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -8,13 +8,16 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Bar struct {
+	ID uint `gorm:"primarykey"`
+}
+
+type Foo struct {
+	ID    uint `gorm:"primarykey"`
+	BarID uint `gorm:"index;NOT NULL"`
+	Bar   Bar
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	DB.Table("foo").AutoMigrate(&Foo{})
 }


### PR DESCRIPTION
## Explain your user case and expected results

I'd like to specify a custom name for the table I'm about to create using `Table("foo")` but that causes a panic when used with `AutoMigrate`. It seems to work with `CreateTable` though followed by a call to `AutoMigrate`.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104f4a2f4]

goroutine 5 [running]:
testing.tRunner.func1.2({0x105670380, 0x105b9f9b0})
	/opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1545 +0x274
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1548 +0x448
panic({0x105670380?, 0x105b9f9b0?})
	/opt/homebrew/Cellar/go/1.21.0/libexec/src/runtime/panic.go:920 +0x26c
gorm.io/gorm/migrator.Migrator.ReorderModels({{0x8?, 0xc0004f9e60?, {0x105741c68?, 0xc0004f9e90?}}}, {0xc0005e6700, 0x1, 0xc000194c18?}, 0x1)
	/Users/cschinnerl/go/src/github.com/ChrisSchinnerl/playground/gorm/migrator/migrator.go:939 +0x644
gorm.io/gorm/migrator.Migrator.AutoMigrate({{0x80?, 0xc0004f9e60?, {0x105741c68?, 0xc0004f9e90?}}}, {0xc0005e6700, 0x1, 0x1})
	/Users/cschinnerl/go/src/github.com/ChrisSchinnerl/playground/gorm/migrator/migrator.go:113 +0x74
gorm.io/gorm.(*DB).AutoMigrate(0xc000194e78?, {0xc0005e6700, 0x1, 0x1})
	/Users/cschinnerl/go/src/github.com/ChrisSchinnerl/playground/gorm/migrator.go:24 +0x54
gorm.io/playground.TestGORM(0x0?)
	/Users/cschinnerl/go/src/github.com/ChrisSchinnerl/playground/main_test.go:22 +0xdc
testing.tRunner(0xc00048eb60, 0x105733e38)
	/opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1595 +0x198
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.21.0/libexec/src/testing/testing.go:1648 +0x5dc
FAIL	gorm.io/playground	0.235s
```

Expected behaviour would be a more meaningful message being returned in case this is a developer error.