### PR TITLE
Unexpected TableName parsing behaviour

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"gorm.io/gorm/schema"
+)
 
 func main() {
 	ns := schema.NamingStrategy{}


### PR DESCRIPTION
## Explain your user case and expected results

Table names containing some of the predefined abbrevations of the NamingStrategy:
https://github.com/go-gorm/gorm/blob/e57e5d8884d801caa4ce0307bcd081f7e889e514/schema/naming.go#L109

will result in them being parsed incorrectly.
For example the struct name `FBIPassport` should become `fbi_passports`, but as it contains `IP` it will be incorrectly parsed to `fb_ipassports`.