### PR TITLE
Returned error is not `gorm.ErrDuplicatedKey` when duplicate entry is being created

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -12,9 +14,8 @@ func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	res := DB.Create(&user)
+	if res.Error != gorm.ErrDuplicatedKey {
+		t.Errorf("Error is not gorm.ErrDuplicateKey")
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
When a duplicate entry is being created the error returned should be `gorm.ErrDuplicateKey` but it's returning a different error.