### PR TITLE
Incorrect ON CONFLICT when using composite primary key

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{ &Tag{}, &Pet{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,9 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	db := DB
+	if err := db.Create(&Pet{FirstName: "Hasso", LastName: "McDog", Tags: []Tag{{Name: "foo"}}}).Error; err != nil {
+		t.Fatal(err)
 	}
+
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,16 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
 type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
+	FirstName string `gorm:"primaryKey"`
+	LastName string `gorm:"primaryKey"`
+	Tags []Tag
 }
 
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
+type Tag struct {
+	PetFirstName string
+	PetLastName string
 	Name string
 }


### PR DESCRIPTION
## Explain your user case and expected results
I'm using a composite primary key for a table that references a list of entities in another table. 

The error I get is
```
2023/10/02 15:24:09 testing postgres...

2023/10/02 15:24:10 gorm-playground/main_test.go:13 ERROR: ON CONFLICT DO UPDATE requires inference specification or constraint name (SQLSTATE 42601)
[0.952ms] [rows:0] INSERT INTO "tags" ("pet_first_name","pet_last_name","name") VALUES ('Hasso','McDog','foo') ON CONFLICT DO UPDATE SET "pet_first_name"="excluded"."pet_first_name","pet_last_name"="excluded"."pet_last_name"

2023/10/02 15:24:10 gorm-playground/main_test.go:13 ERROR: ON CONFLICT DO UPDATE requires inference specification or constraint name (SQLSTATE 42601)
[3.761ms] [rows:1] INSERT INTO "pets" ("first_name","last_name") VALUES ('Hasso','McDog')
--- FAIL: TestGORM (0.00s)
    main_test.go:14: ERROR: ON CONFLICT DO UPDATE requires inference specification or constraint name (SQLSTATE 42601)
FAIL
FAIL	gorm.io/playground	0.238s
```
