### PR TITLE
Bad insertion IDs when doing a bulk Upsert

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,11 +83,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&Item{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
-
-	DB.Migrator().DropTable("user_friends", "user_speaks")
 
 	if err = DB.Migrator().DropTable(allModels...); err != nil {
 		log.Printf("Failed to drop table, got error %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -9,12 +10,73 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	if err := DB.AutoMigrate(&Item{}); err != nil {
+		fmt.Println("Failed to auto-migrate:", err)
+		return
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	items := []Item{
+		{Name: "Item1"},
+		{Name: "Item2"},
+		{Name: "Item3"},
+		{Name: "Item4"},
+		{Name: "Item5"},
+		{Name: "Item6"},
+	}
+
+	if err := DB.Model(&Item{}).
+		Omit(clause.Associations).
+		Clauses(clause.OnConflict{
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
+		}).
+		Create(&items).Error; err != nil {
+		fmt.Println("Item creation failed:", err)
+		return
+	}
+
+	for _, item := range items {
+		fmt.Println("Initial insert ID:", item.ID)
+	}
+
+	newItems := []Item{
+		{Name: "Item1"},
+		{Name: "Item2"},
+		{Name: "Item7"},
+		{Name: "Item3"},
+		{Name: "Item4"},
+		{Name: "Item8"},
+	}
+
+	if err := DB.Model(&Item{}).
+		Omit(clause.Associations).
+		Clauses(clause.OnConflict{
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at"}),
+		}).
+		Create(&newItems).Error; err != nil {
+		fmt.Println("Item creation failed:", err)
+		return
+	}
+
+	for _, item := range newItems {
+		fmt.Println("After upsert ID:", item.ID)
+	}
+
+	var actualItems []Item
+	if err := DB.Find(&actualItems).Error; err != nil {
+		fmt.Println("Failed to fetch items:", err)
+		return
+	}
+
+	fmt.Println("Real IDs from DB:")
+	for _, item := range actualItems {
+		fmt.Println("ID:", item.ID, ", Name:", item.Name)
+	}
+
+	expectedIDs := []uint64{1, 2, 3, 4, 5, 6, 7, 8}
+	for i, actualItem := range actualItems {
+		if actualItem.ID != expectedIDs[i] {
+			t.Errorf("Unexpected ID for %s: got %d, want %d", actualItem.Name, actualItem.ID, expectedIDs[i])
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git

--- a/models.go
+++ b/models.go
@@ -1,60 +1,12 @@
 package main
 
 import (
-	"database/sql"
 	"time"
-
-	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Item struct {
+	ID        uint64    `gorm:"primaryKey;autoIncrement:true"`
+	Name      string    `gorm:"unique"`
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

When bulk inserting rows with a OnConflict / DoUpdates clause, generated IDs are wrong. 

The case shows how to reproduce this.