### PR TITLE
Inconsistent Behavior with Nested Transactions Depending on Parent Context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -20,9 +20,9 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,56 @@
 package main
 
 import (
+	"errors"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
+func TestGORM1(t *testing.T) {
+	user := User{Name: "jinzhu1"}
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	var errResult error
+	db := DB
+	db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&user).Error; err != nil {
+			t.Errorf("failed to create user, err: %s", err.Error())
+		}
+
+		// db is parent of this transaction
+		errResult = db.First(&result, user.ID).Error
+
+		return nil
+	})
+
+	if !errors.Is(errResult, gorm.ErrRecordNotFound) {
+		t.Errorf("failed, got error %v", errResult)
+	}
+}
+
+func TestGORM2(t *testing.T) {
+	user := User{Name: "jinzhu2"}
+
+	var result User
+	var errResult error
+	db := DB.Begin()
+	db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&user).Error; err != nil {
+			t.Errorf("failed to create user, err: %s", err.Error())
+		}
+
+		// db is parent of this transaction
+		errResult = db.First(&result, user.ID).Error
+
+		return nil
+	})
+
+	if !errors.Is(errResult, gorm.ErrRecordNotFound) {
+		t.Errorf("failed, got error %v", errResult)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

I am developing a server application using gorm—thank you for providing such a useful ORM tool. In production, we operate directly on the database itself, but in our testing environment, we utilize transactions (tx) to maintain test parallelism. This difference seems to be leading to the behavioral discrepancies as demonstrated in the tests.

Is this a bug, or is it an inevitable aspect of the nested transaction implementation? We observe that when a transaction is nested within another transaction (tx within tx), it behaves differently compared to when the parent context is the database connection itself.

We would expect the behavior to be consistent regardless of the parent context being a transaction or a direct database connection, to ensure reliability and predictability in both testing and production environments.