### PR TITLE
AutoMigrate recreates table with composite unique index even if the m…

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -72,6 +75,8 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
 	}
 
+	db.Logger = logger.New(customLogger, logger.Config{LogLevel: logger.Info})
+
 	if debug := os.Getenv("DEBUG"); debug == "true" {
 		db.Logger = db.Logger.LogMode(logger.Info)
 	} else if debug == "false" {
@@ -105,4 +110,18 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+}
+
+var logHistory strings.Builder
+var customLogger testLogger
+
+type testLogger struct{}
+
+func (testLogger) Printf(format string, a ...interface{}) {
+	logHistory.WriteString(fmt.Sprintf(format, a...))
+}
+
+func readLog() string {
+	defer logHistory.Reset()
+	return logHistory.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -16,13 +16,15 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgx/v5 v5.5.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.18 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.15.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm


### PR DESCRIPTION

## Explain your user case and expected results


In my use case, in sqlite driver, I have a model Gateway with a composite unique index defined on the fields IP and UIN. I expect that when running AutoMigrate, the table should only be recreated if there are changes to the model structure. However, I observed that the table is recreated every time AutoMigrate is called, even when the model has not changed.


Expected results:

When using a composite unique index, the table should not be recreated during AutoMigrate if the model structure has not changed.
The unique attribute should be properly set for fields within a composite unique index, without affecting the behavior of AutoMigrate.
After modifying the condition in the sqlite-driver code as mentioned in the original issue description, the behavior is as expected and the table is not recreated during AutoMigrate when the model has not changed.