### PR TITLE
demonstrate ON CONFLICT failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -16,13 +16,15 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgx/v5 v5.5.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.18 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.15.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"database/sql"
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,10 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	DB.Create(&Toy{Name: "1", OwnerID: "2", OwnerType: "3"})
+	DB.Create(&Account{UserID: sql.NullInt64{Int64: 999}, Number: "666"})
+	t.Log("create success")
+	dbUpsert := DB.Clauses(clause.OnConflict{UpdateAll: true})
+	dbUpsert.Create(&Toy{Name: "1", OwnerID: "2", OwnerType: "3"})
+	dbUpsert.Create(&Account{UserID: sql.NullInt64{Int64: 999}, Number: "666"})
 }


### PR DESCRIPTION
Use case: I run two `DB.Create()` statements with `ON CONFLICT` set.

Expected result: The program does not crash.

Actual result: The program crashes with a panic.