### PR TITLE
bug: postgres driver tries to insert slices and arrays as records, and fails

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Test{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,16 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	test := Test{Data: []float64{8, 4, 2, 1, 0.5}}
+
+	err := DB.Create(&test).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	var result2 Test
+	if err := DB.First(&result2).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,7 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Test struct {
+	Data []float64 `gorm:"type:float8[]"`
+}


### PR DESCRIPTION
## Explain your user case and expected results
When inserting go arrays or slices in a GORM model, the generated SQL uses them as records, so the insert fails.

For example:
```go
type Test struct {
	Data []float64 `gorm:"type:float8[]"`
}

test := Test{Data: []float64{8, 4, 2, 1, 0.5}}
DB.Create(&test)
```
gives the SQL:
```sql
INSERT INTO "tests" ("data") VALUES ((8,4,2,1,0.5))
```
And I get the error `ERROR: column "data" is of type double precision[] but expression is of type record (SQLSTATE 42804)`

Instead, the SQL should be:
```sql
INSERT INTO "tests" ("data") VALUES ('{8,4,2,1,0.5}')
```
or
```sql
INSERT INTO "tests" ("data") VALUES (ARRAY [8,4,2,1,0.5])
```