### PR TITLE
Bug: db.Find on custom string types

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,28 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", SomeCustomString: "test"}
 
 	DB.Create(&user)
 
+	// the following statement works
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if result.SomeCustomString != "test" {
+		t.Errorf("Failed, expected: %v, got: %v", "test", result.SomeCustomString)
+	}
+
+	// the following statement works
+	var strResult string
+	if err := DB.Model(&User{}).Where("id = ?", user.ID).Select("some_custom_string").Find(&strResult).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// the following statement does not work
+	var customStrResult CustomString
+	if err := DB.Model(&User{}).Where("id = ?", user.ID).Select("some_custom_string").Find(&customStrResult).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -13,21 +13,24 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	Name             string
+	Age              uint
+	Birthday         *time.Time
+	Account          Account
+	Pets             []*Pet
+	Toys             []Toy `gorm:"polymorphic:Owner"`
+	CompanyID        *int
+	Company          Company
+	ManagerID        *uint
+	Manager          *User
+	Team             []User     `gorm:"foreignkey:ManagerID"`
+	Languages        []Language `gorm:"many2many:UserSpeak"`
+	Friends          []*User    `gorm:"many2many:user_friends"`
+	Active           bool
+	SomeCustomString CustomString
 }
+
+type CustomString string
 
 type Account struct {
 	gorm.Model


### PR DESCRIPTION
## Explain your user case and expected results

GORM generally handles custom string types effectively when SQL results are mapped into a model or a string. However, when attempting to map results to a custom string type, an unrelated error message is encountered:
```
Failed, got error: sql: Scan called without calling Next
```
This issue arises specifically in the context of mapping results to custom string types, suggesting a potential bug or undocumented requirement in GORM's handling of such types.