### PR TITLE
Fixed issues with playground on MacOS Apple Sillicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,4 @@ services:
       - MSSQL_DB=gorm
       - MSSQL_USER=gorm
       - MSSQL_PASSWORD=LoremIpsum86
+      - MSSQL_SA_PASSWORD=LoremIpsum86

--- a/test.sh
+++ b/test.sh
@@ -16,10 +16,10 @@ if [[ -z $GITHUB_ACTION ]]; then
   if [[ $(uname -a) == *" arm64" ]]; then
     MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker-compose up --detach --quiet-pull || true
     echo "starting"
-    go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest || true
-    SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" > /dev/null || true
-    SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" > /dev/null || true
-    SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" > /dev/null || true
+    go install github.com/microsoft/go-sqlcmd/cmd/modern@latest || true
+    SQLCMDPASSWORD=LoremIpsum86 modern -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" > /dev/null || true
+    SQLCMDPASSWORD=LoremIpsum86 modern -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" > /dev/null || true
+    SQLCMDPASSWORD=LoremIpsum86 modern -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" > /dev/null || true
   else
     docker-compose up --detach --quiet-pull
     echo "starting..."


### PR DESCRIPTION
## Explain your user case and expected results

This PR relates to playground itself and it's issues on apple sillicon.

The environmental variable for db password for mssql has changed. 
Also the `sqlcmd` did not work because the main package in github.com/microsoft/go-sqlcmd has changed
