### PR TITLE
preloading with foreignKey and references overwrite

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,11 +83,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&Org{}, &Country1{}, &Country2{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
-
-	DB.Migrator().DropTable("user_friends", "user_speaks")
 
 	if err = DB.Migrator().DropTable(allModels...); err != nil {
 		log.Printf("Failed to drop table, got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -15,14 +15,16 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.19 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm/clause"
 	"testing"
 )
 
@@ -9,12 +10,32 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	c1_1 := Country1{Name: "c1_1"}
+	c1_2 := Country1{Name: "c1_2"}
+	c2_1 := Country2{CName: "c2_1"}
+	c2_2 := Country2{CName: "c2_2"}
 
-	DB.Create(&user)
+	org := Org{
+		Adress1_1: Address1{Country: c1_1},
+		Adress1_2: Address1{Country: c1_2},
+		Adress2_1: Address2{Country: c2_1},
+		Adress2_2: Address2{Country: c2_2},
+	}
+	DB.Create(&org)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	var result Org
+	DB.Preload(clause.Associations).First(&result)
+
+	if result.Adress1_1.Country.Name != "c1_1" {
+		t.Error("Adress1_1 country has not been resolved")
+	}
+	if result.Adress1_2.Country.Name != "c1_2" {
+		t.Error("Adress1_2 country has not been resolved")
+	}
+	if result.Adress2_1.Country.CName != "c2_1" {
+		t.Error("Adress2_1 country has not been resolved")
+	}
+	if result.Adress2_2.Country.CName != "c2_2" {
+		t.Error("Adress2_2 country has not been resolved")
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,27 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+type Country1 struct {
+	Name string `gorm:"primaryKey"`
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
+type Country2 struct {
+	CName string `gorm:"primaryKey"`
 }
 
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
+type Address1 struct {
+	CountryName string
+	Country     Country1
 }
 
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
+type Address2 struct {
+	CName   string
+	Country Country2 `gorm:"foreignKey:CName;references:CName"`
 }
 
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Org struct {
+	ID        int
+	Adress1_1 Address1 `gorm:"embedded;embeddedPrefix:address1_1_"`
+	Adress1_2 Address1 `gorm:"embedded;embeddedPrefix:address1_2_"`
+	Adress2_1 Address2 `gorm:"embedded;embeddedPrefix:address2_1_"`
+	Adress2_2 Address2 `gorm:"embedded;embeddedPrefix:address2_2_"`
 }


### PR DESCRIPTION
## Explain your user case and expected results
When using a belongs-to relation with foreignKey and references overwrite preloading does not work. (`Adress2`)
When not overwriting it works as expected. (`Address1`)
```
type Country1 struct {
	Name string `gorm:"primaryKey"`
}

type Country2 struct {
	CName string `gorm:"primaryKey"`
}

type Address1 struct {
	CountryName string
	Country     Country1
}

type Address2 struct {
	CName   string
	Country Country2 `gorm:"foreignKey:CName;references:CName"`
}
```