### PR TITLE
wrong foreignKey setup for multiple ebedded belongs-to relations

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,11 +83,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&Org{}, &Country{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
-
-	DB.Migrator().DropTable("user_friends", "user_speaks")
 
 	if err = DB.Migrator().DropTable(allModels...); err != nil {
 		log.Printf("Failed to drop table, got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -15,14 +15,16 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.19 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -9,12 +10,31 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	country := Country{Name: "Test"}
+	address1 := Address{
+		Country: country,
+	}
+	org := Org{
+		Address1: address1,
+		Address2: address1,
+	}
 
-	DB.Create(&user)
+	DB.Create(&org)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	stmt := &gorm.Statement{DB: DB}
+	stmt.Parse(&org)
+
+	belongsTo := stmt.Schema.Relationships.BelongsTo
+	embedded := stmt.Schema.Relationships.EmbeddedRelations
+	relations := stmt.Schema.Relationships.Relations
+
+	if len(belongsTo) != 2 {
+		t.Errorf("Expected 2 belongsTo, got %v", len(belongsTo))
+	}
+	if len(embedded) != 2 {
+		t.Errorf("Expected 2 embedded, got %v", len(embedded))
+	}
+	if len(relations) != 2 {
+		t.Errorf("Expected 2 relations, got %v", len(relations))
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,16 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+type Country struct {
+	Name string `gorm:"primaryKey"`
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
+type Address struct {
+	CountryName string
+	Country     Country
 }
 
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Org struct {
+	ID       int
+	Address1 Address `gorm:"embedded;embeddedPrefix:address1_"`
+	Address2 Address `gorm:"embedded;embeddedPrefix:address2_"`
 }


### PR DESCRIPTION
## Explain your user case and expected results
When using multiple embedded belongs-to relations only 1 database foreignKey is created.
Expected: a foreignKey for each relation is created.

```
type Country struct {
	Name string `gorm:"primaryKey"`
}

type Address struct {
	CountryName string
	Country     Country
}

type Org struct {
	ID       int
	Address1 Address `gorm:"embedded;embeddedPrefix:address1_"`
	Address2 Address `gorm:"embedded;embeddedPrefix:address2_"`
}
```
In the above example there should be a foreignKey for _address1 -> countries_ and a foreignKey _address2 -> countries_.
gorm only creates one foreignKey `fk_orgs_country` => `address2_country_name->countries`

Hint:
* the generated naming for the foreignKey should respect the fieldName with its path / parent struct, as both relations result in the same foreignKey name. 
* the relations are correctly detected as embedded and belongs-to, but result in only one entry in the relations map, this is due to the fact that only fieldName is used within this map
* possible solution: consider using BindNames of the field for name generation


