### PR TITLE
DropIndex and RenameIndex fail in postgres driver when TablePrefix is…

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
 )
 
 var DB *gorm.DB
@@ -49,13 +50,19 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 		}
-		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				TablePrefix: "myschema.",
+			}})
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				TablePrefix: "myschema.",
+			}})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;
@@ -66,10 +73,17 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "sqlserver://gorm:LoremIpsum86@localhost:9930?database=gorm"
 		}
-		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				TablePrefix: "myschema.",
+			}})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				TablePrefix: "myschema.",
+			},
+		})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {
@@ -86,6 +100,8 @@ func RunMigrations() {
 	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
+
+	DB.Exec(`CREATE SCHEMA IF NOT EXISTS "myschema"`)
 
 	DB.Migrator().DropTable("user_friends", "user_speaks")
 

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,21 @@ go 1.16
 
 require (
 	github.com/denisenkom/go-mssqldb v0.12.2 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
-	gorm.io/driver/mysql v1.4.1
-	gorm.io/driver/postgres v1.4.4
-	gorm.io/driver/sqlite v1.4.2
-	gorm.io/driver/sqlserver v1.4.1
-	gorm.io/gorm v1.24.0
+	github.com/jackc/pgconn v1.14.1 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v5 v5.5.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.19 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,15 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// Drop index failure
+	// err := DB.Migrator().DropIndex(&User{}, "name_idx")
+	// if err != nil {
+	// 	t.Errorf("failed to drop index, got error %v\n", err)
+	// }
 
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	// Rename index failure
+	// err := DB.Migrator().RenameIndex(&User{}, "name_idx", "name_idx2")
+	// if err != nil {
+	// 	t.Errorf("failed to rename index, got error %v\n", err)
+	// }
 }

--- a/models.go
+++ b/models.go
@@ -13,7 +13,7 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
+	Name      string `gorm:"index:name_idx"`
 	Age       uint
 	Birthday  *time.Time
 	Account   Account


### PR DESCRIPTION
… used to specify schema

## Explain your user case and expected results
To reproduce the issue for each function, comment in the respective block in TestGORM. run tests with the dialect set to "postgres" as there is dialect-specific SQL used to create the non-default schema.

I would expect that these two functions would use m.CurrentTable to table TablePrefix into account, but they do not. Explicitly adding the schema to the index name in the function argument makes these tests work, which confirms the cause.