### PR TITLE
demonstrate cannot change column in BeforeUpdate()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.1
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.2
+	gorm.io/driver/postgres v1.5.4
+	gorm.io/driver/sqlite v1.5.4
+	gorm.io/driver/sqlserver v1.5.2
+	gorm.io/gorm v1.25.5
 )
 
 require (
@@ -15,14 +15,16 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.19 // indirect
+	github.com/microsoft/go-mssqldb v1.6.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"gorm.io/gorm"
+	"strings"
 	"testing"
 )
 
@@ -9,12 +11,45 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "     jinzhu     "}
 
-	DB.Create(&user)
+	err := DB.Create(&user).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+	// Works fine with create
+	if result.Name != "jinzhu" {
+		t.Errorf("Failed, got name: %v. Expected: %v", result.Name, "jinzhu")
+	}
+
+	// Add a name with non-UTF8 characters so that the update will error if characters are not removed
+	userBrokenName := User{Name: "     tux     "}
+	if err := DB.Model(&user).Updates(userBrokenName).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	// Does not work with update
+	if result.Name != "tux" {
+		t.Errorf("Failed, got name: %v. Expected: tux", result.Name)
+	}
+}
+
+func (u *User) BeforeCreate(tx *gorm.DB) (err error) {
+	cleanName := strings.TrimSpace(u.Name) // remove trailing whitespace
+	u.Name = cleanName
+	return nil
+}
+
+func (u *User) BeforeUpdate(tx *gorm.DB) (err error) {
+	cleanName := strings.TrimSpace(u.Name) // remove trailing whitespace
+	u.Name = cleanName
+	return nil
 }


### PR DESCRIPTION
## Explain your user case and expected results

I would like to be able to use BeforeUpdate() to modify a column value, before updating. For example, I may want to trim any whitespace on the value before updating it in the database. The functionality is possible with the BeforeCreate() hook, but it does not seem to be possible with the BeforeUpdate() hook.

in my code example, you can see I create a user ` "    jinzhu     "`. In the BeforeCreate() method, I trim the whitespace and update the value, and the query uses the _updated_ value.

In my code example, I update the user to the name` "    tux    "`. In the BeforeUpdate() method, I trim the whitespace and update the value, but the actual update query still uses the _original_ value. I would expect it to use the updated value.