### PR TITLE
Pluck panics in a busy connection and canceled context

### DIFF
--- a/db.go
+++ b/db.go
@@ -55,7 +55,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{
+			SkipDefaultTransaction: true,
+		})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;

--- a/go.mod
+++ b/go.mod
@@ -32,4 +32,4 @@ require (
 	gorm.io/plugin/dbresolver v1.5.0 // indirect
 )
 
-replace gorm.io/gorm => ./gorm
+// replace gorm.io/gorm => ./gorm

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/playground
 go 1.20
 
 require (
+	golang.org/x/sync v0.5.0
 	gorm.io/driver/mysql v1.5.2
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.3

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 	"testing"
@@ -34,13 +33,9 @@ func TestGORM(t *testing.T) {
 			g.Go(
 				func() error {
 
-					if i == 6000 {
-						return errors.New("fake error")
-					}
-
 					var userName string
 
-					result := session.
+					result := tx.
 						WithContext(ctx).
 						Table("users").
 						Where("id = ?", i).
@@ -72,7 +67,7 @@ func TestGORM(t *testing.T) {
 						return result.Error
 					}
 
-					result = session.Table("users").
+					result = tx.Table("users").
 						WithContext(ctx).
 						Where("active = ?", true).
 						Update("name", "new_name")

--- a/main_test.go
+++ b/main_test.go
@@ -69,8 +69,8 @@ func TestGORM(t *testing.T) {
 
 					result = tx.Table("users").
 						WithContext(ctx).
-						Where("active = ?", true).
-						Update("name", "new_name")
+						Where("id = ?", i).
+						Update("active", true)
 					if result.Error != nil {
 						t.Errorf("Failed during update, got error: %v", result.Error)
 						return result.Error

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,94 @@
 package main
 
 import (
+	"context"
+	"gorm.io/gorm"
+	"sync"
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+// Use this command to test:
+// GORM_DIALECT=postgres go test
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Active: true, Name: "jinzhu"}
 
-	DB.Create(&user)
+	session := DB.Session(&gorm.Session{})
+	for i := 0; i < 1000000; i++ {
+		user.ID = uint(i + 1)
+		session.WithContext(context.Background()).Create(&user)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err := DB.Transaction(func(tx *gorm.DB) error {
+
+		var wg sync.WaitGroup
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		cancel()
+
+		for i := 0; i < 1000000; i++ {
+			i := i
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				var userName string
+
+				result := session.
+					WithContext(ctx).
+					Table("users").
+					Where("id = ?", i).
+					Pluck("name", &userName)
+
+				// When the driver returns `conn busy` and the context is canceled, Pluck panics:
+				// panic: runtime error: index out of range [0] with length 0
+				// github.com/jackc/pgx/v4/stdlib.(*Rows).Next(0x140000a2320, {0x10549fb80, 0x0, 0x104896cdc?})
+				//        external/com_github_jackc_pgx_v4/stdlib/sql.go:767 +0x14d0
+				// database/sql.(*Rows).nextLocked(0x140004a4d00)
+				//        GOROOT/src/database/sql/sql.go:2974 +0x160
+				// database/sql.(*Rows).Next.func1()
+				//        GOROOT/src/database/sql/sql.go:2952 +0x30
+				// database/sql.withLock({0x104ea0a58, 0x140004a4d30}, 0x140005692a8)
+				//        GOROOT/src/database/sql/sql.go:3405 +0x7c
+				// database/sql.(*Rows).Next(0x140004a4d00)
+				//        GOROOT/src/database/sql/sql.go:2951 +0x64
+				// gorm.io/gorm.Scan({0x104ea5890, 0x140004a4d00}, 0x140003b0540, 0x0)
+				//        external/io_gorm_gorm/scan.go:159 +0x15c8
+				// gorm.io/gorm/callbacks.Query(0x140003b0540)
+				//        external/io_gorm_gorm/callbacks/query.go:26 +0xec
+				// gorm.io/gorm.(*processor).Execute(0x14000447130, 0x1400001aab0?)
+				//        external/io_gorm_gorm/callbacks.go:130 +0x3d0
+				// gorm.io/gorm.(*DB).Pluck(0x140007a2180?, {0x104b663b1, 0x2}, {0x104d3a3c0?, 0x140006228c0})
+				//        external/io_gorm_gorm/finisher_api.go:542 +0x24c
+
+				if result.Error != nil {
+					t.Errorf("Failed during read, got error: %v", result.Error)
+					return
+				}
+
+				result = session.Table("users").
+					WithContext(ctx).
+					Where("active = ?", true).
+					Update("name", "new_name")
+				if result.Error != nil {
+					t.Errorf("Failed during update, got error: %v", result.Error)
+					return
+				}
+
+			}()
+		}
+
+		wg.Wait()
+
+		return nil
+	})
+
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
+	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
-	"sync"
 	"testing"
-	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -19,71 +19,76 @@ func TestGORM(t *testing.T) {
 	user := User{Active: true, Name: "jinzhu"}
 
 	session := DB.Session(&gorm.Session{})
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 8000; i++ {
 		user.ID = uint(i + 1)
 		session.WithContext(context.Background()).Create(&user)
 	}
 
 	err := DB.Transaction(func(tx *gorm.DB) error {
 
-		var wg sync.WaitGroup
+		g, ctx := errgroup.WithContext(context.Background())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		cancel()
-
-		for i := 0; i < 1000000; i++ {
+		for i := 0; i < 8000; i++ {
 			i := i
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
 
-				var userName string
+			g.Go(
+				func() error {
 
-				result := session.
-					WithContext(ctx).
-					Table("users").
-					Where("id = ?", i).
-					Pluck("name", &userName)
+					if i == 6000 {
+						return errors.New("fake error")
+					}
 
-				// When the driver returns `conn busy` and the context is canceled, Pluck panics:
-				// panic: runtime error: index out of range [0] with length 0
-				// github.com/jackc/pgx/v4/stdlib.(*Rows).Next(0x140000a2320, {0x10549fb80, 0x0, 0x104896cdc?})
-				//        external/com_github_jackc_pgx_v4/stdlib/sql.go:767 +0x14d0
-				// database/sql.(*Rows).nextLocked(0x140004a4d00)
-				//        GOROOT/src/database/sql/sql.go:2974 +0x160
-				// database/sql.(*Rows).Next.func1()
-				//        GOROOT/src/database/sql/sql.go:2952 +0x30
-				// database/sql.withLock({0x104ea0a58, 0x140004a4d30}, 0x140005692a8)
-				//        GOROOT/src/database/sql/sql.go:3405 +0x7c
-				// database/sql.(*Rows).Next(0x140004a4d00)
-				//        GOROOT/src/database/sql/sql.go:2951 +0x64
-				// gorm.io/gorm.Scan({0x104ea5890, 0x140004a4d00}, 0x140003b0540, 0x0)
-				//        external/io_gorm_gorm/scan.go:159 +0x15c8
-				// gorm.io/gorm/callbacks.Query(0x140003b0540)
-				//        external/io_gorm_gorm/callbacks/query.go:26 +0xec
-				// gorm.io/gorm.(*processor).Execute(0x14000447130, 0x1400001aab0?)
-				//        external/io_gorm_gorm/callbacks.go:130 +0x3d0
-				// gorm.io/gorm.(*DB).Pluck(0x140007a2180?, {0x104b663b1, 0x2}, {0x104d3a3c0?, 0x140006228c0})
-				//        external/io_gorm_gorm/finisher_api.go:542 +0x24c
+					var userName string
 
-				if result.Error != nil {
-					t.Errorf("Failed during read, got error: %v", result.Error)
-					return
-				}
+					result := session.
+						WithContext(ctx).
+						Table("users").
+						Where("id = ?", i).
+						Pluck("name", &userName)
 
-				result = session.Table("users").
-					WithContext(ctx).
-					Where("active = ?", true).
-					Update("name", "new_name")
-				if result.Error != nil {
-					t.Errorf("Failed during update, got error: %v", result.Error)
-					return
-				}
+					// When the driver returns `conn busy` and the context is canceled, Pluck panics:
+					// panic: runtime error: index out of range [0] with length 0
+					// github.com/jackc/pgx/v4/stdlib.(*Rows).Next(0x140000a2320, {0x10549fb80, 0x0, 0x104896cdc?})
+					//        external/com_github_jackc_pgx_v4/stdlib/sql.go:767 +0x14d0
+					// database/sql.(*Rows).nextLocked(0x140004a4d00)
+					//        GOROOT/src/database/sql/sql.go:2974 +0x160
+					// database/sql.(*Rows).Next.func1()
+					//        GOROOT/src/database/sql/sql.go:2952 +0x30
+					// database/sql.withLock({0x104ea0a58, 0x140004a4d30}, 0x140005692a8)
+					//        GOROOT/src/database/sql/sql.go:3405 +0x7c
+					// database/sql.(*Rows).Next(0x140004a4d00)
+					//        GOROOT/src/database/sql/sql.go:2951 +0x64
+					// gorm.io/gorm.Scan({0x104ea5890, 0x140004a4d00}, 0x140003b0540, 0x0)
+					//        external/io_gorm_gorm/scan.go:159 +0x15c8
+					// gorm.io/gorm/callbacks.Query(0x140003b0540)
+					//        external/io_gorm_gorm/callbacks/query.go:26 +0xec
+					// gorm.io/gorm.(*processor).Execute(0x14000447130, 0x1400001aab0?)
+					//        external/io_gorm_gorm/callbacks.go:130 +0x3d0
+					// gorm.io/gorm.(*DB).Pluck(0x140007a2180?, {0x104b663b1, 0x2}, {0x104d3a3c0?, 0x140006228c0})
+					//        external/io_gorm_gorm/finisher_api.go:542 +0x24c
 
-			}()
+					if result.Error != nil {
+						t.Errorf("Failed during read, got error: %v", result.Error)
+						return result.Error
+					}
+
+					result = session.Table("users").
+						WithContext(ctx).
+						Where("active = ?", true).
+						Update("name", "new_name")
+					if result.Error != nil {
+						t.Errorf("Failed during update, got error: %v", result.Error)
+						return result.Error
+					}
+
+					return nil
+
+				})
 		}
 
-		wg.Wait()
+		if err := g.Wait(); err != nil {
+			t.Errorf("Failed, got error: %v", err)
+		}
 
 		return nil
 	})


### PR DESCRIPTION
## Explain your user case and expected results
The test is just a "forced" scenario where 8,000 users are created and then read/updated one by one in a single DB transaction under the same context in a go routine.

We expect to have 8,000 go routines (one per user) executing:
- one read operation by ID via `Pluck`
- one update operation by ID

I am using `errgroup` to manage the cancelation of the context (passed to Gorm) in case of errors.

Give a try (more than once, to get the panic error):
```sh
GORM_DIALECT=postgres go test
```

Error:
```sh
panic: runtime error: index out of range [0] with length 0

goroutine 1571 [running]:
github.com/jackc/pgx/v5/stdlib.(*Rows).Next(0x14000654140, {0x101221ad0, 0x0, 0x100599048?})
        /Users/xxx/go/pkg/mod/github.com/jackc/pgx/v5@v5.4.3/stdlib/sql.go:754 +0xfd8
database/sql.(*Rows).nextLocked(0x14002c32080)
        /opt/homebrew/opt/go/libexec/src/database/sql/sql.go:2974 +0x160
database/sql.(*Rows).Next.func1()
        /opt/homebrew/opt/go/libexec/src/database/sql/sql.go:2952 +0x30
database/sql.withLock({0x100d807d0, 0x14002c320b0}, 0x14002aaf2c8)
        /opt/homebrew/opt/go/libexec/src/database/sql/sql.go:3405 +0x7c
database/sql.(*Rows).Next(0x14002c32080)
        /opt/homebrew/opt/go/libexec/src/database/sql/sql.go:2951 +0x64
gorm.io/gorm.Scan({0x100d84670, 0x14002c32080}, 0x14002a9cb40, 0x0)
        /Users/xxx/go/pkg/mod/gorm.io/gorm@v1.25.4/scan.go:175 +0x1784
gorm.io/gorm/callbacks.Query(0x14002a9cb40)
        /Users/xxx/go/pkg/mod/gorm.io/gorm@v1.25.4/callbacks/query.go:28 +0xec
gorm.io/gorm.(*processor).Execute(0x140002c87d0, 0x140002de240?)
        /Users/xxx/go/pkg/mod/gorm.io/gorm@v1.25.4/callbacks.go:130 +0x384
gorm.io/gorm.(*DB).Pluck(0x5e1?, {0x100a38706, 0x4}, {0x100c61ba0?, 0x14001798a90})
        /Users/xxx/go/pkg/mod/gorm.io/gorm@v1.25.4/finisher_api.go:568 +0x254
gorm.io/playground.TestGORM.func1.1()
        /Users/xxx/GolandProjects/playground/main_test.go:42 +0x140
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/xxx/go/pkg/mod/golang.org/x/sync@v0.5.0/errgroup/errgroup.go:75 +0x5c
created by golang.org/x/sync/errgroup.(*Group).Go
        /Users/xxx/go/pkg/mod/golang.org/x/sync@v0.5.0/errgroup/errgroup.go:72 +0xa0
```

Probably related to:
https://github.com/lib/pq/issues/81

In any case, it would be nice to be able to handle this panic in Gorm if there is this limitation.