### PR TITLE
unexpected unscoped behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/driver/mysql v1.5.4
+	gorm.io/driver/postgres v1.5.6
+	gorm.io/driver/sqlite v1.5.5
+	gorm.io/driver/sqlserver v1.5.3
 	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.7-0.20240204074919-46816ad31dde
 )
 
 require (
@@ -16,19 +16,21 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.3 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/microsoft/go-mssqldb v1.7.0 // indirect
+	golang.org/x/crypto v0.19.0 // indirect
+	golang.org/x/mod v0.15.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.18.0 // indirect
+	gorm.io/datatypes v1.2.0 // indirect
+	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.5.0 // indirect
 )
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,58 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	user := User{
+		Model: gorm.Model{
+			ID: 1,
+		},
+		Name: "jinzhu",
+		Pets: []*Pet{
+			{
+				Model: gorm.Model{
+					ID: 1,
+				},
+				UserID: &[]uint{1}[0],
+				Toy: Toy{
+					OwnerID: 1,
+				},
+			},
+		},
 	}
+
+	tcs := []struct {
+		name             string
+		shouldHardDelete bool
+	}{
+		{
+			name:             "soft delete",
+			shouldHardDelete: false,
+		},
+		{
+			name:             "hard delete",
+			shouldHardDelete: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := DB.Begin()
+			tx.Create(&user)
+
+			if tc.shouldHardDelete {
+				tx = tx.Unscoped()
+			}
+
+			if err := tx.Select(clause.Associations).Delete(&user).Error; err != nil {
+				t.Errorf("Failed, got error: %v", err)
+			}
+
+			du := User{Model: gorm.Model{ID: 1}}
+			if err := tx.Find(&du).Error; err != nil {
+				t.Errorf("Failed, got error: %v", err)
+			}
+
+			tx.Rollback()
+		})
+	}
+
 }

--- a/models.go
+++ b/models.go
@@ -45,7 +45,7 @@ type Pet struct {
 type Toy struct {
 	gorm.Model
 	Name      string
-	OwnerID   string
+	OwnerID   uint
 	OwnerType string
 }
 


### PR DESCRIPTION
## Explain your user case and expected results
When I want to hard delete records and use Unscoped to reassign the gorm.DB structure, the first Delete statement works correctly, but the second Delete statement does not. Why is this happening?　What can I do to avoid this?

### code
```go
if tc.shouldHardDelete {
	tx = tx.Unscoped()
}

// delete pets separately to delete pets' association
if err := tx.Select(clause.Associations).Delete(&user.Pets).Error; err != nil {
	t.Errorf("Failed, got error: %v", err)
}

if err := tx.Select(clause.Associations).Delete(&user).Error; err != nil {
	t.Errorf("Failed, got error: %v", err)
}
```

### SQL Log
```sql
$ DEBUG=true ./test.sh

2024/02/23 07:36:17 /Users/kyota/programing/playground/main_test.go:59
[0.055ms] [rows:1] DELETE FROM `toys` WHERE `toys`.`owner_type` = "pets" AND `toys`.`owner_id` = 1

2024/02/23 07:36:17 /Users/kyota/programing/playground/main_test.go:59
[0.162ms] [rows:1] DELETE FROM `pets` WHERE `pets`.`id` = 1

2024/02/23 07:36:17 /Users/kyota/programing/playground/main_test.go:63
[0.048ms] [rows:0] DELETE FROM `toys` WHERE `toys`.`owner_type` = "pets" AND `toys`.`owner_id` = 1

2024/02/23 07:36:17 /Users/kyota/programing/playground/main_test.go:63
[0.171ms] [rows:0] DELETE FROM `pets` WHERE `pets`.`id` = 1 AND `pets`.`id` = 1 AND `pets`.`id` = 1

2024/02/23 07:36:17 /Users/kyota/programing/playground/main_test.go:68 near "as": syntax error
[0.041ms] [rows:0] SELECT ~~~as~~~ FROM `pets` WHERE `pets`.`id` = 1 AND `pets`.`id` = 1 AND `pets`.`id` = 1 ORDER BY `pets`.`id` LIMIT 1
    main_test.go:72: Failed, got error: near "as": syntax error
--- FAIL: TestGORM (0.01s)
    --- PASS: TestGORM/soft_delete (0.00s)
    --- FAIL: TestGORM/hard_delete (0.00s)
FAIL
FAIL    gorm.io/playground      0.439s
FAIL
```