### PR TITLE
test: ? literal in regexp_like

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -17,4 +17,18 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+
+	sql1 := `select name, age, birthday, active from users where name ~ '(zh){0,}.*' and name like ?`
+	if rows, err := DB.Raw(sql1, "%in%").Rows(); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	} else {
+		t.Logf("Succeeded, got result: %v", rows.Next())
+	}
+
+	sql2 := `select name, age, birthday, active from users where name ~ '(zh)?.*' and name like ?`
+	if rows, err := DB.Raw(sql2, "%in%").Rows(); err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	} else {
+		t.Logf("Succeeded, got result: %v", rows.Next())
+	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When `?` literal is part of the SQL statement for regexp pattern (not as a placeholder), gorm will still treat such literal as a placeholder and hence throw an error.

This is a bug.

```
=== RUN   TestGORM

2024/03/10 15:31:27 /Users/ericsun/workspace/git/gorm-playground/main_test.go:14
[1.757ms] [rows:1] INSERT INTO "users" ("created_at","updated_at","deleted_at","name","age","birthday","company_id","manager_id","active") VALUES ('2024-03-10 15:31:27.611','2024-03-10 15:31:27.611',NULL,'jinzhu',0,NULL,NULL,NULL,false) RETURNING "id"

2024/03/10 15:31:27 /Users/ericsun/workspace/git/gorm-playground/main_test.go:17
[0.826ms] [rows:1] SELECT * FROM "users" WHERE "users"."id" = 1 AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1

2024/03/10 15:31:27 /Users/ericsun/workspace/git/gorm-playground/main_test.go:22
[0.649ms] [rows:-] select name, age, birthday, active from users where name ~ '(zh){0,}.*' and name like '%in%'
    main_test.go:25: Succeeded, got result: true

2024/03/10 15:31:27 /Users/ericsun/workspace/git/gorm-playground/main_test.go:29 ERROR: syntax error at end of input (SQLSTATE 42601)
[24.548ms] [rows:-] select name, age, birthday, active from users where name ~ '(zh)'%in%'.*' and name like ?
    main_test.go:30: Failed, got error: ERROR: syntax error at end of input (SQLSTATE 42601)
--- FAIL: TestGORM (0.03s)
FAIL
```