### PR TITLE
MySQL: AutoMigrate to add primary key is not working

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,33 +3,36 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/driver/mysql v1.5.6
+	gorm.io/driver/postgres v1.5.7
+	gorm.io/driver/sqlite v1.5.5
+	gorm.io/driver/sqlserver v1.5.3
 	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.9
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.5 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/microsoft/go-mssqldb v1.7.0 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/mod v0.16.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.19.0 // indirect
+	gorm.io/datatypes v1.2.0 // indirect
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.5.1 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -16,5 +17,68 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+// I think second TestCase should pass but fails
+func Test_primaryKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		prepare  func() error
+		wantType string
+		wantKey  string
+	}{
+		{
+			name: "ok: TenantID to be Primary Key in init AutoMigrate",
+			prepare: func() error {
+				return DB.Table("tenant").AutoMigrate(&TenantWithPrimaryKey{})
+			},
+			wantType: "varchar(36)",
+			wantKey:  "PRI",
+		},
+		{
+			name: "should be ok but fails: TenantID to be Primary Key in second AutoMigrate",
+			prepare: func() error {
+				if err := DB.Table("tenant").AutoMigrate(&TenantWithoutPrimaryKey{}); err != nil {
+					return err
+				}
+				return DB.Table("tenant").AutoMigrate(&TenantWithPrimaryKey{})
+			},
+			wantType: "varchar(36)",
+			wantKey:  "PRI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.prepare(); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := DB.Exec("DROP TABLE tenant").Error; err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			type column struct {
+				Type string
+				Key  string
+			}
+
+			var c column
+			if err := DB.Raw("SHOW COLUMNS FROM tenant").First(&c).Error; err != nil {
+				t.Fatal(err)
+			}
+
+			fmt.Println(c)
+
+			gotType, gotKey := c.Type, c.Key
+			if gotType != tt.wantType {
+				t.Fatalf("gotType = %s, wantType = %s", gotType, tt.wantType)
+			}
+			if gotKey != tt.wantKey {
+				t.Fatalf("gotKey = %s, wantKey = %s", gotKey, tt.wantKey)
+			}
+		})
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,11 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type TenantWithoutPrimaryKey struct {
+	TenantID string `gorm:"type:VARCHAR(36)"`
+}
+
+type TenantWithPrimaryKey struct {
+	TenantID string `gorm:"type:VARCHAR(36);primaryKey"`
+}


### PR DESCRIPTION
## Explain your user case and expected results
### DB
* mysql

### How To Reproduce
1. AutoMigrate structA without primary key specification
2. add primary key to some existing column in StructA then run AutoMigrate

### Expected
* after step 2, primary key added to the column

### Result
* primary key not added

