### PR TITLE
feat: insert record with ID assigned doesn't commit the sequence ID

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,12 +4,10 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
-	"gorm.io/driver/sqlite"
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -68,8 +66,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		}
 		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
 	default:
-		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		log.Println("testing postgres...")
+		if dbDSN == "" {
+			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+		}
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {

--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,3 @@ require (
 	gorm.io/hints v1.1.0 // indirect
 	gorm.io/plugin/dbresolver v1.5.0 // indirect
 )
-
-replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -9,12 +10,21 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// I have used Postgres for the test
+	userWithAssignedID := User{
+		Model: gorm.Model{ // first create with an assigned ID -> record is successfully inserted
+			ID: 1,
+		},
+		Name: "jinzhu",
+	}
 
-	DB.Create(&user)
+	DB.Create(&userWithAssignedID)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	userWithoutAssignedID := User{
+		Name: "jinzhu", // Since the ID 1 is already assigned to a record, ideally GORM should
+	} // have checked and used the next available sequence value.
+	err := DB.Create(&userWithoutAssignedID).Error
+	if err != nil {
+		t.Error(err.Error())
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When a record is inserted with an assigned ID using db.Create(), that sequence ID is not committed. 
Example: Given the sequence ID for user table is at ID: 2. 
and if I create an entity 
`User {ID: 5, Name: "some user" }`
 with ID 5 assigned, gorm creates the entity. So, when the turn for ID 5 with auto-sequence comes in, pkey violation error occurs. 

The expected result would be , that GORM would see ID 5 is already used by another record and use continue from ID 6. 