### PR TITLE
queries: n+1 queries

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,21 +1,5 @@
 package main
 
-import (
-	"gorm.io/gen"
-	"gorm.io/gen/examples/dal"
-)
-
 func generate() {
-	g := gen.NewGenerator(gen.Config{
-		OutPath: "./dal/query",
-		Mode:    gen.WithDefaultQuery, /*WithQueryInterface, WithoutContext*/
 
-		WithUnitTest: true,
-	})
-	g.UseDB(dal.DB)
-
-	g.ApplyBasic(Company{}, Language{}) // Associations
-	g.ApplyBasic(g.GenerateModel("user"), g.GenerateModelAs("account", "AccountInfo"))
-
-	g.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.9
 )
 
 require (
@@ -23,13 +22,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	github.com/microsoft/go-mssqldb v1.5.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
 )
 
-replace gorm.io/gorm => ./gorm
+//replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,55 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	users := []User{
+		{
+			Name: "Alexis",
+			Company: &Company{
+				Name: "Google",
+				Addresses: []Addresses{
+					{Name: "Mountain View"},
+					{Name: "New York"},
+				},
+			},
+		},
+		{
+			Name: "Jinzhu",
+			Company: &Company{
+				Name: "Google",
+				Addresses: []Addresses{
+					{Name: "Lyndhurst"},
+					{Name: "California"},
+				},
+			},
+		},
+	}
 
-	DB.Create(&user)
+	DB.Create(&users)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var result []User
+	customLogger.record = true
+	err := DB.
+		Joins("Company").
+		Preload("Company.Addresses").
+		Find(&result).Error
+
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	// queries should be like:
+	// - SELECT `users`.`id`,`users`.`created_at`,`users`.`updated_at`,`users`.`deleted_at`,`users`.`name`,`Company`.`id` AS `Company__id`,`Company`.`name` AS `Company__name`,`Company`.`user_id` AS `Company__user_id` FROM `users`
+	//		LEFT JOIN `companies` `Company` ON `users`.`id` = `Company`.`user_id`
+	//		WHERE `users`.`deleted_at` IS NULL
+	//
+	// - SELECT * FROM `companies` WHERE `companies`.`id` IN (1, 2)
+	//
+	// It should have 2 queries, not 3
+	// Gorm is doing a n+1 query here, but it should not
+	//
+	// In version v1.25.6 the select of addresses where using a IN clause but have the problem of doing a second query with companies (https://github.com/go-gorm/gorm/issues/6715#issuecomment-1832455676)
+
+	if len(queries) != 2 {
+		t.Errorf("Failed, expect 2 queries, but got %v", len(queries))
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,25 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
 	"gorm.io/gorm"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
-}
-
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
+	Name    string
+	Company *Company
 }
 
 type Company struct {
-	ID   int
-	Name string
+	ID        int
+	Name      string
+	UserID    uint
+	Addresses []Addresses
 }
 
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type Addresses struct {
+	ID        int
+	Name      string
+	CompanyID uint
+	Company   Company
 }


### PR DESCRIPTION
## Description
This pull request aims to demonstrate an issue in GORM's query behavior as observed in the provided test function TestGORM. The function illustrates potential inefficiencies and unexpected results that may have been introduced due to a previous fix in GORM's preloading and join operations.

### Background
Previously, a fix was implemented in GORM to address an issue where, when joining on Account.Pet and then preloading Account.Companies, the account was loaded twice, even though it was already present in the main query. This fix aimed to improve the consistency and efficiency of the query process.

### Current Issue
However, the provided test function suggests that the fix may have unintentionally introduced another issue. The test highlights the following:

- Unexpected Queries: The function is expected to execute two queries (one for fetching user data and another for related data). Instead, there may be an additional, unnecessary query, suggesting an n+1 query problem.

TLDR: 

```go
DB.Joins("Company").Preload("Company.Addresses").Find(&result).Error
```

is resulting in 

```
2024/04/23 15:08:19 /Users/alexisviscogliosi/dev/go-playground/db.go:59
[1.205ms] [rows:2] SELECT * FROM "addresses" WHERE "addresses"."company_id" = 1

2024/04/23 15:08:19 /Users/alexisviscogliosi/dev/go-playground/db.go:59
[0.634ms] [rows:2] SELECT * FROM "addresses" WHERE "addresses"."company_id" = 2

2024/04/23 15:08:19 /Users/alexisviscogliosi/dev/go-playground/db.go:59
[3.667ms] [rows:2] SELECT "users"."id","users"."created_at","users"."updated_at","users"."deleted_at","users"."name","Company"."id" AS "Company__id","Company"."name" AS "Company__name","Company"."user_id" AS "Company__user_id" FROM "users" LEFT JOIN "companies" "Company" ON "users"."id" = "Company"."user_id
```

Instead of 

```
SELECT `users`.`id`,`users`.`created_at`,`users`.`updated_at`,`users`.`deleted_at`,`users`.`name`,`Company`.`id` AS `Company__id`,`Company`.`name` AS `Company__name`,`Company`.`user_id` AS `Company__user_id` FROM `users
		LEFT JOIN `companies` `Company` ON `users`.`id` = `Company`.`user_id`
		WHERE `users`.`deleted_at` IS NULL
SELECT * FROM `companies` WHERE `companies`.`id` IN (1, 2)
```

- Preloading Behavior: The use of preloading (Preload("Company.Addresses")) may be causing unexpected query behavior or inefficiencies. The preloading process might not be functioning as expected, potentially due to the previous fix.

### Demonstration Purpose
This pull request serves as a demonstration of the potential impact of changes in GORM's behavior, particularly in relation to preloading and joining operations. It provides an opportunity to understand how these changes might affect database efficiency and application performance.

