### PR TITLE
`go-gorm/sharding` plugin would fail when combining with hints.ForceIndex

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,21 +1,5 @@
 package main
 
-import (
-	"gorm.io/gen"
-	"gorm.io/gen/examples/dal"
-)
-
 func generate() {
-	g := gen.NewGenerator(gen.Config{
-		OutPath: "./dal/query",
-		Mode:    gen.WithDefaultQuery, /*WithQueryInterface, WithoutContext*/
 
-		WithUnitTest: true,
-	})
-	g.UseDB(dal.DB)
-
-	g.ApplyBasic(Company{}, Language{}) // Associations
-	g.ApplyBasic(g.GenerateModel("user"), g.GenerateModelAs("account", "AccountInfo"))
-
-	g.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,35 +1,44 @@
 module gorm.io/playground
 
-go 1.20
+go 1.21
+
+toolchain go1.22.0
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
+	gorm.io/driver/mysql v1.5.6
+	gorm.io/driver/postgres v1.5.7
+	gorm.io/driver/sqlite v1.5.5
+	gorm.io/driver/sqlserver v1.5.3
 	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.7
+	gorm.io/hints v1.1.2
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/bwmarrin/snowflake v0.3.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
+	github.com/jackc/pgx/v5 v5.5.5 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
+	github.com/longbridgeapp/sqlparser v0.3.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/microsoft/go-mssqldb v1.7.1 // indirect
+	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
 	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	gorm.io/sharding v0.6.1 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/models.go
+++ b/models.go
@@ -58,3 +58,29 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Message struct {
+	Id      uint
+	Content string `gorm:"index:idx_content"`
+}
+
+func (Message) TableName() string {
+	return "message"
+}
+
+// Message1 and Message2 are used for creating sharding table of Message
+type Message1 struct {
+	*Message
+}
+
+func (Message1) TableName() string {
+	return "message_01"
+}
+
+type Message2 struct {
+	*Message
+}
+
+func (Message2) TableName() string {
+	return "message_02"
+}


### PR DESCRIPTION
## Explain your user case and expected results
I create a logical table named `message`, and use two underlying sharding tables: `message_01` and `message_02`.
When using `go-gorm/sharding` plugin alone, everything works well, as in test case `TestSharding`.
However, after I added `Clauses(hints.ForceIndex("idx_content"))` in the query, the sharding plugin would fail, as in test case `TestShardingAndForceIndex`.