### PR TITLE
add uniqueIndex for AutoMigrate

### DIFF
--- a/db.go
+++ b/db.go
@@ -49,7 +49,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 		}
-		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(dbDSN), &gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+		})
 	case "postgres":
 		log.Println("testing postgres...")
 		if dbDSN == "" {

--- a/models.go
+++ b/models.go
@@ -13,20 +13,21 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+	Name        string
+	EnglishName string `json:"englishName" gorm:"uniqueIndex:idx_english_name;column:englishName;type:varchar(100);comment:英文名;"`
+	Age         uint
+	Birthday    *time.Time
+	Account     Account
+	Pets        []*Pet
+	Toys        []Toy `gorm:"polymorphic:Owner"`
+	CompanyID   *int
+	Company     Company
+	ManagerID   *uint
+	Manager     *User
+	Team        []User     `gorm:"foreignkey:ManagerID"`
+	Languages   []Language `gorm:"many2many:UserSpeak"`
+	Friends     []*User    `gorm:"many2many:user_friends"`
+	Active      bool
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

```
type User struct {
	EnglishName string `json:"englishName" gorm:"uniqueIndex:idx_english_name;column:englishName;type:varchar(100);comment:英文名;"`
}
```

执行

```
DB.AutoMigrate(&User{})
```

的时候，初次执行正常，再次执行报错：

```
ALTER TABLE t_users DROP FOREIGN KEY uni_t_users_english_name
AutoMigrate for table faild. err:Error 1091 (42000): Can't DROP 'uni_t_users_english_name'; check that column/key exists
```

实际上是没有这个外键的，但依然会drop这个外键。

预期结果：

判断此外键是否存在，存在再去执行 Drop 方法。