### PR TITLE
bug: when using OnConflict for batch insertion, the returned ID is incorrect

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,58 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	addedUsers := []UniqueUser{
+		{
+			Name: "Alice",
+			Age:  18,
+		},
+		{
+			Name: "Bob",
+			Age:  22,
+		},
+		{
+			Name: "Cindy",
+			Age:  25,
+		},
+	}
 
-	DB.Create(&user)
+	// Drop TABLE IF EXISTS
+	DB.Migrator().DropTable(&UniqueUser{})
+	DB.AutoMigrate(&UniqueUser{})
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// create users
+	DB.Create(&addedUsers)
+
+	// In this case, I use a new slice, to simulate another business scenario
+	// where new data is obtained and needs to be updated
+	newUsers := []UniqueUser{}
+	// one year later
+	for _, user := range addedUsers {
+		newUsers = append(newUsers, UniqueUser{
+			Name: user.Name,
+			Age:  user.Age + 1,
+		})
+	}
+
+	// update users, use on conflict to update all fields
+	DB.Clauses(clause.OnConflict{
+		// add Columns to compatible with sqlite
+		Columns:   []clause.Column{{Name: "name"}},
+		UpdateAll: true,
+	}).Create(&newUsers)
+
+	// The bug here is that when using OnConflict{UpdateAll: true} for batch insertion,
+	// if there is an update, the returned ID is incorrect
+
+	// In this test case,
+	// the expected result is that the second time the insertion is executed,
+	// it should actually be updated,
+	// so the ID returned by the corresponding object should be the same as the first time.
+	for i := range newUsers {
+		firseCreateUser := addedUsers[i]
+		secondCreateUser := newUsers[i]
+		if firseCreateUser.ID != secondCreateUser.ID {
+			t.Errorf("Expected ID %d, got %d", firseCreateUser.ID, secondCreateUser.ID)
+		}
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,9 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type UniqueUser struct {
+	gorm.Model
+	Name string `gorm:"unique;type:varchar(32)"`
+	Age  uint
+}


### PR DESCRIPTION
The bug here is that when using OnConflict{UpdateAll: true} for batch insertion, if there is an update, the returned ID is incorrect