### PR TITLE
Broken backward compatibility with join and preload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,25 @@
 module gorm.io/playground
 
-go 1.20
+go 1.21
+
+toolchain go1.22.0
 
 require (
+	github.com/stretchr/testify v1.8.1
 	gorm.io/driver/mysql v1.5.2
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.3
 	gorm.io/driver/sqlserver v1.5.1
 	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.10
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -25,11 +36,9 @@ require (
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
 	gorm.io/hints v1.1.0 // indirect
 	gorm.io/plugin/dbresolver v1.5.0 // indirect
 )
-
-replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,57 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Foo struct {
+	ID     int
+	BarID  string
+	FooBar *Bar `gorm:"foreignKey:BarID;references:ID"`
+}
+
+type Bar struct {
+	ID   string
+	Type string
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	err := DB.Migrator().DropTable(&Foo{}, &Bar{})
+	require.NoError(t, err)
 
-	DB.Create(&user)
+	err = DB.AutoMigrate(&Foo{}, &Bar{})
+	require.NoError(t, err)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	bar := []*Bar{
+		{ID: "Bar-first", Type: "first"},
+		{ID: "Bar-second", Type: "second"},
 	}
+	require.NoError(t, DB.Create(bar).Error)
+
+	foo := []Foo{
+		{BarID: bar[0].ID, ID: 1},
+		{BarID: bar[1].ID, ID: 2},
+	}
+	require.NoError(t, DB.Create(foo).Error)
+
+	var out Foo
+
+	// Select that does not populate end struct, but shows broken backward compatibility.
+	builder := DB.Select("foos.*, (?)", DB.Table("bars").Select("type"))
+	// builer := DB.Table("foos") would work.
+
+	builder = builder.
+		Preload("FooBar").
+		Joins("FooBar")
+	builder = builder.Model(Foo{})
+	builder = builder.Where(`"FooBar".type IN ?`, []string{"first"})
+
+	res := builder.Find(&out)
+	require.NoError(t, res.Error)
+	require.EqualValues(t, bar[0], out.FooBar)
 }


### PR DESCRIPTION
Starting from v1.25.7, gorm is having trouble unmarshalling data into desired struct when the query returns any insignificant rows after using Preload and Joins. 