### PR TITLE
Failed migration with `unique` tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,33 +3,35 @@ module gorm.io/playground
 go 1.20
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
+	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/postgres v1.5.9
+	gorm.io/driver/sqlite v1.5.6
 	gorm.io/driver/sqlserver v1.5.1
 	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/gorm v1.25.11
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/mod v0.19.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/tools v0.23.0 // indirect
+	gorm.io/datatypes v1.2.1 // indirect
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.5.2 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,23 @@
 package main
 
 import (
-	"testing"
+    "testing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+type Author struct {
+    ID      string `gorm:"primaryKey"`
+    Books []Book   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;unique"`
+}
+
+type Book struct {
+    ID       string `gorm:"primaryKey"`
+    AuthorID string
+}
+
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+    DB.AutoMigrate(&Author{}, &Book{})
 }


### PR DESCRIPTION
## Explain your user case and expected results

Upgrading gorm to `1.25.11` results in an error during migration. The same code worked with the version I was using before (1.25.2)

MRE in the PR.

```
2024/07/23 13:17:59 /home/fabio/dev/gorm-bug/main.go:31 ERROR: unterminated quoted identifier at or near ""))" (SQLSTATE 42601)
[0.243ms] [rows:0] CREATE TABLE "authors" ("id" text,PRIMARY KEY ("id"),CONSTRAINT "uni_authors_" UNIQUE ("))
```

