### PR TITLE
test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gorm
 go.sum
 .*
 *.db
+vendor

--- a/gen.go
+++ b/gen.go
@@ -1,21 +1,16 @@
 package main
 
-import (
-	"gorm.io/gen"
-	"gorm.io/gen/examples/dal"
-)
-
 func generate() {
-	g := gen.NewGenerator(gen.Config{
-		OutPath: "./dal/query",
-		Mode:    gen.WithDefaultQuery, /*WithQueryInterface, WithoutContext*/
-
-		WithUnitTest: true,
-	})
-	g.UseDB(dal.DB)
-
-	g.ApplyBasic(Company{}, Language{}) // Associations
-	g.ApplyBasic(g.GenerateModel("user"), g.GenerateModelAs("account", "AccountInfo"))
-
-	g.Execute()
+	// g := gen.NewGenerator(gen.Config{
+	// 	OutPath: "./dal/query",
+	// 	Mode:    gen.WithDefaultQuery, /*WithQueryInterface, WithoutContext*/
+	//
+	// 	WithUnitTest: true,
+	// })
+	// g.UseDB(dal.DB)
+	//
+	// g.ApplyBasic(Company{}, Language{}) // Associations
+	// g.ApplyBasic(g.GenerateModel("user"), g.GenerateModelAs("account", "AccountInfo"))
+	//
+	// g.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/playground
 go 1.20
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	gorm.io/driver/mysql v1.5.2
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.3
@@ -25,7 +26,7 @@ require (
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
 	gorm.io/hints v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,33 +4,30 @@ go 1.20
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/postgres v1.5.9
+	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/sqlserver v1.5.3
+	gorm.io/gorm v1.25.10
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/microsoft/go-mssqldb v1.7.2 // indirect
+	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -37,10 +37,11 @@ func TestGORM(t *testing.T) {
 		)
 	}).First(&out)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE "active" = $1 AND ("id" = $2 or "name" = $3) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1`)).
-		WithArgs(true, id, name).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).
-			AddRow(id))
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`SELECT * FROM "users" WHERE "active" = $1 AND ("id" = $2 or "name" = $3) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1`,
+		),
+	).WithArgs(true, id, name)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -39,9 +39,9 @@ func TestGORM(t *testing.T) {
 
 	mock.ExpectQuery(
 		regexp.QuoteMeta(
-			`SELECT * FROM "users" WHERE "active" = $1 AND ("id" = $2 or "name" = $3) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1`,
+			`SELECT * FROM "users" WHERE "active" = $1 AND ("id" = $2 or "name" = $3) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT $7`,
 		),
-	).WithArgs(true, id, name)
+	).WithArgs(true, id, name, 1)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,48 @@
 package main
 
 import (
+	"regexp"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: postgres
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
 
-	DB.Create(&user)
+	gdb, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:       db,
+		DriverName: "postgres",
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	const id = 1
+	const name = "b"
+	var out *User
+	gdb.Model(&User{}).Where("active", true).Scopes(func(d *gorm.DB) *gorm.DB {
+		return d.Where(
+			d.Where("id", id).Or("name", name),
+		)
+	}).First(&out)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE "active" = $1 AND ("id" = $2 or "name" = $3) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT 1`)).
+		WithArgs(true, id, name).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow(id))
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

I was under the impression that using a grouped where cond in a query scope, would apply to the query only 1 time.

The results I'm seeing from applying a grouped cond in a query scope such as:
```go
func ScopeSomething(a,b string) func (*gorm.DB) *gorm.DB {
  return func (db *gorm.DB) *gorm.DB {
    return db.Where(
      // would anticipate the following being added to query as ("field_a" = ? OR "field_b" = ?)
      db.Where("field_a", a).Or("field_b", b),
    )
  }
}
```

This generates a query such as:
```sql
SELECT * FROM sometable WHERE field_a = ? or field_b = ? AND (field_a = ? OR field_b = ?)
```

The desired behavior can be achieved by doing the following but it doesn't feel as proper.
```go
func ScopeSomething(a,b string) func (*gorm.DB) *gorm.DB {
  return func (db *gorm.DB) *gorm.DB {
    return db.Where("field_a = ? OR field_b = ?", a, b)
  }
}
```

Actual Test QB:
```go
gdb.Model(&User{}).Where("active", true).Scopes(func(d *gorm.DB) *gorm.DB {
  return d.Where(
    d.Where("id", id).Or("name", name),
  )
}).First(&out)
```

Actual Test Query Output:
```SQL
SELECT * FROM "users" WHERE ("active" = $1 AND "id" = $2 OR "name" = $3 AND ("active" = $4 AND "id" = $5 OR "name" = $6)) AND "users"."deleted_at" IS NULL ORDER BY "users"."id" LIMIT $7
```