### PR TITLE
Nested transaction bug using a wrapper function

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"math/rand"
 	"os"
@@ -105,4 +106,12 @@ func RunMigrations() {
 			os.Exit(1)
 		}
 	}
+}
+
+func Transaction(ctx context.Context, db *gorm.DB, apply func(ctx context.Context, db *gorm.DB) error) error {
+	return db.
+		WithContext(ctx).
+		Transaction(func(db *gorm.DB) error {
+			return apply(ctx, db)
+		})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,40 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
+	// Create a wrapping transaction
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
+	var account Account
+	err := Transaction(context.Background(), DB, func(ctx context.Context, tx *gorm.DB) error {
+		// Within this, create a transaction that retrieves a user, and then
+		// creates another transaction that retrieves the account, but errors,
+		// and bubble that error up.
+		return Transaction(ctx, tx, func(ctx context.Context, tx *gorm.DB) error {
+			err := tx.First(&user, 1).Error
+			if err != nil {
+				return err
+			}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+			// Since we propagate the error, we'll now also try to
+			// rollback this nested transaction, using the same
+			// savepoint ID, since the `Transaction` helper
+			// creates a single closure that always has the
+			// same address.
+			return Transaction(ctx, tx, func(ctx context.Context, tx *gorm.DB) error {
+				// We haven't created an account, so we return an error, which does
+				// a rollback of the inner transaction using a savepoint.
+				err := tx.First(&account, 1).Error
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+		})
+	})
+
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"gorm.io/gorm"
@@ -12,19 +13,26 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	// Create a wrapping transaction
+	var user User
+	err := DB.First(&user, "name = ?", "jinzhu").Error
+	// ensure we start with no user
+	if err == nil {
+		t.Errorf("User %d already exists", user.ID)
+	}
 
-	err := Transaction(context.Background(), DB, func(ctx context.Context, tx *gorm.DB) error {
+	// Create a wrapping transaction
+	err = Transaction(context.Background(), DB, func(ctx context.Context, tx *gorm.DB) error {
 		// Within this, create a transaction that retrieves a user, and then
 		// creates another transaction that retrieves the account, but errors,
 		// and bubble that error up.
-		_ = Transaction(ctx, tx, func(ctx context.Context, tx *gorm.DB) error {
+		err := Transaction(ctx, tx, func(ctx context.Context, tx *gorm.DB) error {
 			user := User{Name: "jinzhu"}
 			var account Account
 			err := DB.Create(&user).Error
 			if err != nil {
 				return err
 			}
+			fmt.Printf("User created: %d", user.ID)
 
 			// Since we propagate the error, we'll now also try to
 			// rollback this nested transaction, using the same
@@ -42,6 +50,9 @@ func TestGORM(t *testing.T) {
 				return nil
 			})
 		})
+		if err == nil {
+			t.Errorf("Expected an error, got none")
+		}
 		// We discard the inner transaction error, which allows us to commit this outer
 		// transaction (which does nothing), even if the inner fails.
 		return nil
@@ -49,9 +60,8 @@ func TestGORM(t *testing.T) {
 
 	// Since we have rolled back the inner transaction, we expect that
 	// no user was created, since we should have rolled that back.
-	var user User
 	err = DB.First(&user, "name = ?", "jinzhu").Error
 	if err == nil {
-		t.Errorf("User was created, despite erroring inside the transaction")
+		t.Errorf("User %d was created, despite erroring inside the transaction", user.ID)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func TestGORM(t *testing.T) {
 		err := Transaction(ctx, tx, func(ctx context.Context, tx *gorm.DB) error {
 			user := User{Name: "jinzhu"}
 			var account Account
-			err := DB.Create(&user).Error
+			err := tx.Create(&user).Error
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Explain your user case and expected results

When wrapping `db.Transaction` in your own function, savepoints are given the same name, due to the logic [here](https://github.com/go-gorm/gorm/blob/master/finisher_api.go#L626). This results in rollbacks not being applied as expected.

I expect to be able to use nested transactions using my own wrapper.