### PR TITLE
array insertion: 

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", Emails: []string{"dummy-email"}}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -15,6 +15,7 @@ type User struct {
 	gorm.Model
 	Name      string
 	Age       uint
+	Emails    []string
 	Birthday  *time.Time
 	Account   Account
 	Pets      []*Pet


### PR DESCRIPTION
# array type insertion failing

A table created with a column which is an Array type does not seem to work with insertions. This PR shows a simple example of what can trigger this, (tested it manually on postgres).

----

Here is an error message i got on a minimal table setup:

```
\d people
                              Table "public.people"
   Column   |  Type  | Collation | Nullable |              Default               
------------+--------+-----------+----------+------------------------------------
 id         | bigint |           | not null | nextval('people_id_seq'::regclass)
 first_name | text   |           |          | 
 last_name  | text   |           |          | 
 names      | text[] |           |          | 
```

```
ERROR:  malformed array literal: "John" from GORM:
DETAIL:  Array value must start with "{" or dimension information.
STATEMENT:  INSERT INTO "people" ("first_name","last_name","names") VALUES ($1,$2,($3)) RETURNING "id"
```
GORM sent: `INSERT INTO "people" ("first_name","last_name","names") VALUES ('John','Doe',('John')) RETURNING "id"`

----

You can correct this in one way by using curly braces around the array:

The correct way to insert:
```
INSERT INTO "people" ("first_name", "last_name", "names") 
VALUES ('John', 'Doe', '{"John"}');
```

Example of failure:

```
INSERT INTO "people" ("first_name", "last_name", "names") 
VALUES ('John', 'Doe', '("John")');
ERROR:  malformed array literal: "("John")"
LINE 2: VALUES ('John', 'Doe', '("John")');
                               ^
DETAIL:  Array value must start with "{" or dimension information.
```

ps:

Since it does not work with insertions, unable to confirm whether this works for other operations, I would expect arrays to work though.

