### PR TITLE
At sign in select strings cause invalid query

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +12,26 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", Age: 30}
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	type result struct {
+		Name      string
+		IsExample bool
+		Age       int
 	}
+	var results []result
+	err := DB.Table("users").Select("name, name = 'test example.com' as is_example", "age").Scan(&results).Error
+	require.NoError(t, err)
+	assert.False(t, results[0].IsExample)
+	assert.Equal(t, results[0].Age, 30)
+
+	// This time, an ampersand character is used in the select string
+	err = DB.Table("users").Select("name, name = 'test@example.com' as is_example", "age").Scan(&results).Error
+	assert.False(t, results[0].IsExample)
+	// Fails, because the @ causes the Select statement to ignore
+	assert.Equal(t, results[0].Age, 30)
+
+	require.NoError(t, err)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -27,10 +27,10 @@ func TestGORM(t *testing.T) {
 	assert.False(t, results[0].IsExample)
 	assert.Equal(t, results[0].Age, 30)
 
-	// This time, an ampersand character is used in the select string
+	// This time, an ampersand character is used in the select string. This causes the "age" string to not be included
+	// as a column in select.
 	err = DB.Table("users").Select("name, name = 'test@example.com' as is_example", "age").Scan(&results).Error
 	assert.False(t, results[0].IsExample)
-	// Fails, because the @ causes the Select statement to ignore
 	assert.Equal(t, results[0].Age, 30)
 
 	require.NoError(t, err)


### PR DESCRIPTION
The below shows an example of two queries that are the same except one contains a string with an ampersand, the other does not. The query with the ampersand in the string ends up not using the rest of the strings in `Select()` when making the query.