### PR TITLE
Using clause.Not and clause.And result in erroneous simplification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,35 +1,53 @@
 module gorm.io/playground
 
-go 1.20
+go 1.22.0
+
+toolchain go1.23.2
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/postgres v1.5.9
+	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/sqlserver v1.5.3
+	gorm.io/gen v0.3.26
+	gorm.io/gen/examples v0.0.0-00010101000000-000000000000
+	gorm.io/gorm v1.25.12
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
+	github.com/microsoft/go-mssqldb v1.7.2 // indirect
+	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
+	golang.org/x/tools v0.26.0 // indirect
+	gorm.io/datatypes v1.2.4 // indirect
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )
 
 replace gorm.io/gorm => ./gorm
+
+replace gorm.io/gen/examples => ./gen/examples
+
+// these allow testing against the last version where the tests passed (v1.25.5)
+replace gorm.io/driver/sqlite => gorm.io/driver/sqlite v1.5.4
+
+replace gorm.io/driver/postgres => gorm.io/driver/postgres v1.5.4
+
+replace gorm.io/driver/mysql => gorm.io/driver/mysql v1.5.2
+
+replace gorm.io/driver/sqlserver => gorm.io/driver/sqlserver v1.5.2

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +11,69 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	DB.Create(&User{Name: "jinzhu", Active: true})
+	DB.Create(&User{Name: "ezequiel", Active: true})
+	DB.Create(&User{Name: "jinzhu", Active: false})
+	DB.Create(&User{Name: "ezequiel", Active: false})
 
-	DB.Create(&user)
+	var results []User
+	conds := clause.Not(clause.And(
+		clause.Eq{
+			Column: clause.Column{Name: "name"},
+			Value:  "jinzhu",
+		},
+		clause.Eq{
+			Column: clause.Column{Name: "active"},
+			Value:  true,
+		},
+	))
+	// Query with `NOT(name = 'jinzhu' AND active = true)` should return last three records
+	// By De Morgan's Law this is equivalent to `name != 'jinzhu' OR active != true`
+	// but current version (since 1.25.6) transforms this to
+	// `name != 'jinzhu' AND active != true` which returns only the last record
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	err := DB.
+		Model(&User{}).
+		Clauses(clause.Where{Exprs: []clause.Expression{conds}}).
+		Find(&results).
+		Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("Failed, expected 3 records, got %v", len(results))
+	}
+	for _, r := range results {
+		if r.Name == "jinzhu" && r.Active {
+			t.Errorf("Failed, unexpected record: %v", r)
+		}
+	}
+
+	conds = clause.Not(clause.Or(
+		clause.Eq{
+			Column: clause.Column{Name: "name"},
+			Value:  "jinzhu",
+		},
+		clause.Eq{
+			Column: clause.Column{Name: "active"},
+			Value:  true,
+		},
+	))
+	// Query with `NOT(name = 'jinzhu' OR active = true)` should return last record
+	err = DB.
+		Model(&User{}).
+		Clauses(clause.Where{Exprs: []clause.Expression{conds}}).
+		Find(&results).
+		Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Failed, expected 1 records, got %v", len(results))
+	}
+	for _, r := range results {
+		if r.Name == "jinzhu" || r.Active {
+			t.Errorf("Failed, unexpected record: %v", r)
+		}
 	}
 }


### PR DESCRIPTION
When using clause.Not and clause.And to create query Where conditions and faulty simplification is applied:

`NOT(col1 = val1 AND col2 = val2)` gets turned into `(col1 <> val1 AND col2 <> val2)`, which is wrong.

 The right simplification is to turn the AND into an OR, by [De Morgan's Laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws), so `(col1 <> OR val1 AND col2 <> val2)`

This is a regression that was introduced into gorm in 1.25.6. Testing against 1.25.5 returns the correct condition and expected rows in the included tests.

(This PR includes changes to the go.mod file to be able to compile as per #751, so it assumes the gorm.io/gen repo has been cloned into the ./gen folder. Additionally, there are some replaces to make sure testing against 1.25.5 can compile, tests still fail against gorm master with and without these replaces). 