### PR TITLE
Panic with json serializer and nil value

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Entity{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -1,35 +1,41 @@
 module gorm.io/playground
 
-go 1.20
+go 1.22.0
 
 require (
-	gorm.io/driver/mysql v1.5.2
-	gorm.io/driver/postgres v1.5.2
-	gorm.io/driver/sqlite v1.5.3
-	gorm.io/driver/sqlserver v1.5.1
-	gorm.io/gen v0.3.25
-	gorm.io/gorm v1.25.4
+	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/postgres v1.5.9
+	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/sqlserver v1.5.4
+	gorm.io/gen v0.3.26
+	gorm.io/gorm v1.25.12
 )
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.4.3 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.17 // indirect
-	github.com/microsoft/go-mssqldb v1.5.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
-	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
-	gorm.io/hints v1.1.0 // indirect
-	gorm.io/plugin/dbresolver v1.5.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
+	github.com/microsoft/go-mssqldb v1.7.2 // indirect
+	golang.org/x/crypto v0.29.0 // indirect
+	golang.org/x/mod v0.22.0 // indirect
+	golang.org/x/sync v0.9.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/text v0.20.0 // indirect
+	golang.org/x/tools v0.27.0 // indirect
+	gorm.io/datatypes v1.2.4 // indirect
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )
 
 replace gorm.io/gorm => ./gorm
+
+replace gorm.io/gen => ./gen

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
+// GORM_GEN_REPO: https://github.com/go-gorm/gen.git
+// GORM_GEN_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
@@ -17,4 +19,12 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestGORM_failure(t *testing.T) {
+	value := &Entity{Name: "value"}
+
+	DB.Create(value)
+
+	DB.Save(value)
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,9 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Entity struct {
+	gorm.Model
+	Name           string
+	AdditionalInfo interface{} `gorm:"serializer:json"`
+}

--- a/test.sh
+++ b/test.sh
@@ -8,20 +8,22 @@ rm -rf gorm
 fi
 
 [ -d gorm ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_REPO | awk '{print $3}'))
+[ -d gen ] || (echo "git clone --depth 1 -b $(cat main_test.go | grep GORM_GEN_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_GEN_REPO | awk '{print $3}')"; git clone --depth 1 -b $(cat main_test.go | grep GORM_GEN_BRANCH | awk '{print $3}') $(cat main_test.go | grep GORM_GEN_REPO | awk '{print $3}'))
+rm -f gen/examples/go.*
 
 go get -u -t ./...
 
 # SqlServer for Mac M1
 if [[ -z $GITHUB_ACTION ]]; then
   if [[ $(uname -a) == *" arm64" ]]; then
-    MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker-compose up --detach --quiet-pull || true
+    MSSQL_IMAGE=mcr.microsoft.com/azure-sql-edge docker compose up --detach --quiet-pull || true
     echo "starting"
     go install github.com/microsoft/go-sqlcmd/cmd/sqlcmd@latest || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF DB_ID('gorm') IS NULL CREATE DATABASE gorm" > /dev/null || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF SUSER_ID (N'gorm') IS NULL CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';" > /dev/null || true
     SQLCMDPASSWORD=LoremIpsum86 sqlcmd -U sa -S localhost:9930 -Q "IF USER_ID (N'gorm') IS NULL CREATE USER gorm FROM LOGIN gorm; ALTER SERVER ROLE sysadmin ADD MEMBER [gorm];" > /dev/null || true
   else
-    docker-compose up --detach --quiet-pull
+    docker compose up --detach --quiet-pull
     echo "starting..."
   fi
 fi


### PR DESCRIPTION
## Explain your user case and expected results

When i save a struct with a json serializer field and `nil` value, gorm panics with this stacktrace:
```
--- FAIL: TestGORM_failure (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x8c5295]

goroutine 53 [running]:
testing.tRunner.func1.2({0xf0dd80, 0x15d6180})
        /usr/local/go/src/testing/testing.go:1631 +0x3f7
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x6b6
panic({0xf0dd80?, 0x15d6180?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
gorm.io/gorm/schema.(*Field).setupValuerAndSetter.func17({0x1109750, 0x25cda20}, {0xf5ab00?, 0xc00034b280?, 0x0?}, {0xf15fa0, 0xc000350000})
        /media/MintData/clones/gorm-playground/gorm/schema/field.go:964 +0x1d5
gorm.io/gorm/callbacks.ConvertToAssignments.func2(0xc0000fd400, {0xf15fa0, 0xc000350000})
        /media/MintData/clones/gorm-playground/gorm/callbacks/update.go:149 +0x126
gorm.io/gorm/callbacks.ConvertToAssignments(0xc000450700)
        /media/MintData/clones/gorm-playground/gorm/callbacks/update.go:288 +0x187d
gorm.io/gorm/callbacks.RegisterDefaultCallbacks.Update.func7(0xc000296a80)
        /media/MintData/clones/gorm-playground/gorm/callbacks/update.go:74 +0x326
gorm.io/gorm.(*processor).Execute(0xc000348a00, 0xc000296a80)
        /media/MintData/clones/gorm-playground/gorm/callbacks.go:130 +0xa78
gorm.io/gorm.(*DB).Save(0xc00030dd70, {0xec8c00, 0xc00034b280})
        /media/MintData/clones/gorm-playground/gorm/finisher_api.go:106 +0x9b8
gorm.io/playground.TestGORM_failure(0xc00044eb60?)
        /media/MintData/clones/gorm-playground/main_test.go:29 +0x105
testing.tRunner(0xc00044eb60, 0x10163f0)
        /usr/local/go/src/testing/testing.go:1689 +0x21f
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1742 +0x826
FAIL    gorm.io/playground      0.177s
FAIL
```

After debugging it seems that the schema.Field has the Serializer set with a jsonserializer.
But when it creates the `serializer` instance in https://github.com/go-gorm/gorm/blob/deceebfab8c460cfee229233aded2821ac6b08eb/schema/field.go#L494 it uses the field `SerializeValuer` instead of Serializer.
Then it will panic in https://github.com/go-gorm/gorm/blob/deceebfab8c460cfee229233aded2821ac6b08eb/schema/field.go#L964 as it never set Serializer.
SerializeValuer is never used again in the codebase.