### PR TITLE
Atlas schema generation broken for postgres

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.3
 
 require (
+	ariga.io/atlas-provider-gorm v0.5.0
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/driver/postgres v1.5.10
 	gorm.io/driver/sqlite v1.5.6
@@ -14,6 +15,7 @@ require (
 )
 
 require (
+	ariga.io/atlas-go-sdk v0.6.4 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
@@ -30,7 +32,6 @@ require (
 	golang.org/x/crypto v0.29.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
 	gorm.io/datatypes v1.2.4 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
+
+	"ariga.io/atlas-provider-gorm/gormschema"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +22,25 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestDBMigrationGeneration(t *testing.T) {
+	type Product struct {
+		gorm.Model
+
+		Code  string
+		Price uint
+	}
+
+	dialect := os.Getenv("GORM_DIALECT")
+	stmts, err := gormschema.New(dialect).Load(&Product{})
+
+	if err != nil {
+		t.Errorf("error loading gorm schema: %v", err)
+	}
+
+	if !strings.Contains(stmts, "idx_products_deleted_at") {
+		t.Errorf("index not found in generated statements: %s", stmts)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results
Since PR https://github.com/go-gorm/postgres/pull/285, the migration generation for Atlas fails. This is likely due to the generation using a mock database that doesn't really have the index.

Expected behavior: It should output a SQL script to create the Products table
Actual behavior: It fails with `error loading gorm schema: failed to create index with name idx_products_deleted_at`