### PR TITLE
Deadlock on sqlite with PrepareStmt = true

### DIFF
--- a/db.go
+++ b/db.go
@@ -32,6 +32,8 @@ func init() {
 			log.Printf("failed to connect database, got error %v\n", err)
 		}
 
+		sqlDB.SetMaxOpenConns(1)
+
 		RunMigrations()
 		if DB.Dialector.Name() == "sqlite" {
 			DB.Exec("PRAGMA foreign_keys = ON")
@@ -69,7 +71,9 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		db, err = gorm.Open(sqlserver.Open(dbDSN), &gorm.Config{})
 	default:
 		log.Println("testing sqlite3...")
-		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{
+			PrepareStmt: true, // set this to false and the test passes
+		})
 	}
 
 	if debug := os.Getenv("DEBUG"); debug == "true" {

--- a/go.mod
+++ b/go.mod
@@ -30,12 +30,9 @@ require (
 	golang.org/x/crypto v0.29.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
 	gorm.io/datatypes v1.2.4 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )
-
-replace gorm.io/gorm => ./gorm


### PR DESCRIPTION
Requirements:
- using sqlite
- setting `sqlDB.SetMaxOpenConns` to `1`
- setting `PrepareStmt` to `true`

There seems to be a race condition if we have 2 goroutines try to call the same db read at the same time (for the test I have multiple goroutines so the test is more likely to hit the race condition):
- one call is in a transaction the other one is not   -> FAIL
- both calls in a transaction                                     -> SUCCESS
- both calls outside of transaction                          -> SUCCESS

If we set `PrepareStmt` to `false` it will work as expected