### PR TITLE
Builder issue: `Where` calls with a multiline string condition don't wrap with parens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.23.3
 
 require (
 	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.10
-	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/postgres v1.5.11
+	gorm.io/driver/sqlite v1.5.7
 	gorm.io/driver/sqlserver v1.5.4
 	gorm.io/gen v0.3.26
 	gorm.io/gorm v1.25.12
@@ -21,19 +21,19 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.7.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
-	github.com/microsoft/go-mssqldb v1.7.2 // indirect
-	golang.org/x/crypto v0.29.0 // indirect
+	github.com/microsoft/go-mssqldb v1.8.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
-	golang.org/x/text v0.20.0 // indirect
-	golang.org/x/tools v0.27.0 // indirect
-	gorm.io/datatypes v1.2.4 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/tools v0.29.0 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -9,12 +10,30 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
+	user := User{
+		Name: "jinzhu",
+	}
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	bday := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	user2 := User{
+		Name:     "sam-wbcx",
+		Birthday: &bday,
+	}
+	DB.Create(&user2)
+
+	var results []User
+	if err := DB.
+		Where(`
+			birthday IS NULL
+			OR birthday < CURRENT_TIMESTAMP
+		`).
+		Where("name = ?", user2.Name).
+		Find(&results).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("Failed, returned %d results", len(results))
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

We have several cases where we use multiline strings in `Where` clauses that are currently working as expected with Gorm v1.21.15, but after attempting to update to the latest version, we're seeing that some parens are no longer being included. I suspect that it has to do with multiline strings, since modifying the test to be a single line causes the test to pass, as does wrapping the multiline clause within it's own parens manually.