### PR TITLE
AutoMigrate Fails to Update ENUM Fields in MySQL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       run: GORM_DIALECT=sqlite ./test.sh
 
   mysql:
-    needs: sqlite
+    # needs: sqlite
     strategy:
       matrix:
         dbversion: ['mysql:latest'] # 'mysql:5.7', 'mysql:5.6'
@@ -79,7 +79,7 @@ jobs:
       run: GORM_ENABLE_CACHE=true GORM_DIALECT=mysql GORM_DSN="gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True" ./test.sh
 
   postgres:
-    needs: sqlite
+    # needs: sqlite
     strategy:
       matrix:
         dbversion: ['postgres:latest'] # 'postgres:11', 'postgres:10'
@@ -123,7 +123,7 @@ jobs:
       run: GORM_ENABLE_CACHE=true GORM_DIALECT=postgres GORM_DSN="user=gorm password=gorm dbname=gorm host=localhost port=9920 sslmode=disable TimeZone=Asia/Shanghai" ./test.sh
 
   sqlserver:
-    needs: sqlite
+    # needs: sqlite
     strategy:
       matrix:
         go: ['1.21']

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ We are using the following configuration run your code (GORM's latest master bra
 We have prepared some structs with relationships in [https://github.com/go-gorm/playground/blob/master/models.go](https://github.com/go-gorm/playground/blob/master/models.go) that you can use for your tests
 
 ## Happy Hacking!
+

--- a/db.go
+++ b/db.go
@@ -89,10 +89,10 @@ func RunMigrations() {
 
 	DB.Migrator().DropTable("user_friends", "user_speaks")
 
-	if err = DB.Migrator().DropTable(allModels...); err != nil {
-		log.Printf("Failed to drop table, got error %v\n", err)
-		os.Exit(1)
-	}
+	// if err = DB.Migrator().DropTable(allModels...); err != nil {
+	// 	log.Printf("Failed to drop table, got error %v\n", err)
+	// 	os.Exit(1)
+	// }
 
 	if err = DB.AutoMigrate(allModels...); err != nil {
 		log.Printf("Failed to auto migrate, but got error %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -11,9 +11,11 @@ import (
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu", UserType: ADMIN}
 	user2 := User{Name: "jinzhu2", UserType: USER}
+	user3 := User{Name: "jinzhu2", UserType: VIEWER}
 
 	DB.Create(&user)
 	DB.Create(&user2)
+	DB.Create(&user3)
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -9,9 +9,11 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", UserType: ADMIN}
+	user2 := User{Name: "jinzhu2", UserType: USER}
 
 	DB.Create(&user)
+	DB.Create(&user2)
 
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {

--- a/models.go
+++ b/models.go
@@ -11,6 +11,13 @@ import (
 // He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
+type UserType string
+
+const (
+	ADMIN UserType = "admin"
+	USER UserType = "user"
+)
+
 type User struct {
 	gorm.Model
 	Name      string
@@ -27,6 +34,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	UserType  UserType `gorm:"type:enum('admin', 'user');default:'user'"`
 }
 
 type Account struct {

--- a/models.go
+++ b/models.go
@@ -16,6 +16,7 @@ type UserType string
 const (
 	ADMIN UserType = "admin"
 	USER UserType = "user"
+	VIEWER UserType = "viewer"
 )
 
 type User struct {
@@ -34,7 +35,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
-	UserType  UserType `gorm:"type:enum('admin', 'user');default:'user'"`
+	UserType  UserType `gorm:"type:enum('admin', 'user', 'viewer');default:'user'"`
 }
 
 type Account struct {


### PR DESCRIPTION
Steps:

1. Define an ENUM field UserType in a GORM model with possible values: 'admin' and 'user'.
2. Modify the model by adding a new ENUM value 'viewer' to UserType.
3. Observe that the new ENUM value 'viewer' is not added to the MySQL schema, and the column remains unchanged.