### PR TITLE
AfterDelete Hook only works with a Delete(&struct) with a struct with PK value populated

### DIFF
--- a/deletetest_models.go
+++ b/deletetest_models.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Subject struct {
+	ID         uint   `gorm:"primarykey"`
+	SubjSrc    string `gorm:"type:bytes;size:8;default:'';"`
+	FileCount  int    `gorm:"default:0;"`
+	PhotoCount int    `gorm:"default:0;"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	DeletedAt  gorm.DeletedAt `gorm:"index"`
+}
+
+func (m *Subject) AfterDelete(tx *gorm.DB) (err error) {
+	if err := tx.Model(m).Updates(map[string]interface{}{
+		"FileCount":  0,
+		"PhotoCount": 0,
+	}).Error; err != nil {
+		return fmt.Errorf("AfterDelete failed for m=%+v with err=%+v", m, err)
+	}
+	return nil
+}
+
+type SubjectMap map[string]Subject
+
+func (m SubjectMap) Get(name string) Subject {
+	if result, ok := m[name]; ok {
+		return result
+	}
+
+	return Subject{}
+}
+
+func (m SubjectMap) Pointer(name string) *Subject {
+	if result, ok := m[name]; ok {
+		return &result
+	}
+
+	return &Subject{}
+}
+
+var SubjectFixtures = SubjectMap{
+	"record1": Subject{SubjSrc: "bulkdelete",
+		FileCount:  10,
+		PhotoCount: 10,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record2": Subject{SubjSrc: "bulkdelete",
+		FileCount:  20,
+		PhotoCount: 20,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record3": Subject{SubjSrc: "bulkdelete",
+		FileCount:  30,
+		PhotoCount: 30,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record4": Subject{SubjSrc: "bulkdelete",
+		FileCount:  40,
+		PhotoCount: 40,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record5": Subject{SubjSrc: "bulkdelete",
+		FileCount:  50,
+		PhotoCount: 50,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record-deleter": Subject{SubjSrc: "singledelete",
+		FileCount:  60,
+		PhotoCount: 60,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record-structdeleter": Subject{SubjSrc: "structdelete",
+		FileCount:  70,
+		PhotoCount: 70,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record-structdeletebyid": Subject{SubjSrc: "structdeletebyid",
+		FileCount:  75,
+		PhotoCount: 75,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	}, "record-singledeletebykey": Subject{SubjSrc: "singledeletebyid",
+		FileCount:  80,
+		PhotoCount: 80,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	},
+	"record-keeper": Subject{SubjSrc: "keeper",
+		FileCount:  999,
+		PhotoCount: 999,
+		CreatedAt:  time.Now().UTC(),
+		UpdatedAt:  time.Now().UTC(),
+		DeletedAt:  gorm.DeletedAt{},
+	}}
+
+// CreateSubjectFixtures inserts known entities into the database for testing.
+func CreateSubjectFixtures() (err error) {
+	for _, entity := range SubjectFixtures {
+		if err := DB.Create(&entity).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module gorm.io/playground
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 
 require (
 	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.10
-	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/postgres v1.5.11
+	gorm.io/driver/sqlite v1.5.7
 	gorm.io/driver/sqlserver v1.5.4
 	gorm.io/gen v0.3.26
 	gorm.io/gorm v1.25.12
@@ -15,25 +15,24 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.8.1 // indirect
+	github.com/go-sql-driver/mysql v1.9.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.7.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
-	github.com/microsoft/go-mssqldb v1.7.2 // indirect
-	golang.org/x/crypto v0.29.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
-	golang.org/x/text v0.20.0 // indirect
-	golang.org/x/tools v0.27.0 // indirect
-	gorm.io/datatypes v1.2.4 // indirect
+	github.com/microsoft/go-mssqldb v1.8.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/mod v0.24.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/tools v0.31.0 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,71 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestDeletion(t *testing.T) {
+	if DB.Migrator().HasTable(&Subject{}) {
+		if err := DB.Migrator().DropTable(&Subject{}); err != nil {
+			t.Logf("Failed to drop table, got error %v\n", err)
+			t.Fail()
+		}
+	}
+	if err := DB.AutoMigrate(&Subject{}); err != nil {
+		t.Logf("Failed to auto migrate, but got error %v\n", err)
+		t.Fail()
+	}
+	// Load data in
+	if err := CreateSubjectFixtures(); err != nil {
+		t.Logf("Failed to load data, but got error %v\n", err)
+		t.Fail()
+	}
+
+	t.Run("structdelete", func(t *testing.T) {
+		structDelete := Subject{}
+		if err := DB.Debug().Model(&Subject{}).Where("subj_src = ?", "structdelete").First(&structDelete).Error; err != nil {
+			t.Logf("Failed to first struct record, but got error %v\n", err)
+			t.FailNow()
+		}
+		if err := DB.Debug().Delete(&structDelete).Error; err != nil {
+			t.Logf("Failed to delete struct record, but got error %v\n", err)
+			t.Fail()
+		}
+	})
+
+	t.Run("structdeletebyid", func(t *testing.T) {
+		structDelete := Subject{}
+		if err := DB.Debug().Model(&Subject{}).Where("subj_src = ?", "structdeletebyid").First(&structDelete).Error; err != nil {
+			t.Logf("Failed to first struct record, but got error %v\n", err)
+			t.FailNow()
+		}
+		if err := DB.Debug().Delete(&Subject{}, structDelete.ID).Error; err != nil {
+			t.Logf("Failed to delete structdeletebyid record, but got error %v\n", err)
+			t.Fail()
+		}
+	})
+
+	t.Run("singledeletebyid", func(t *testing.T) {
+		structDelete := Subject{}
+		if err := DB.Debug().Model(&Subject{}).Where("subj_src = ?", "singledeletebyid").First(&structDelete).Error; err != nil {
+			t.Logf("Failed to first struct record, but got error %v\n", err)
+			t.FailNow()
+		}
+		if err := DB.Debug().Where("id = ?", structDelete.ID).Delete(&Subject{}).Error; err != nil {
+			t.Logf("Failed to delete singledeletebyid record, but got error %v\n", err)
+			t.Fail()
+		}
+	})
+
+	t.Run("singledelete", func(t *testing.T) {
+		if err := DB.Debug().Where("subj_src = ?", "singledelete").Delete(&Subject{SubjSrc: "singledelete"}).Error; err != nil {
+			t.Logf("Failed to delete single record, but got error %v\n", err)
+			t.Fail()
+		}
+	})
+
+	t.Run("bulkdelete", func(t *testing.T) {
+		if err := DB.Debug().Where("subj_src = ?", "bulkdelete").Delete(&Subject{}).Error; err != nil {
+			t.Logf("Failed to delete bulk record, but got error %v\n", err)
+			t.Fail()
+		}
+	})
+}


### PR DESCRIPTION
## Explain your user case and expected results
When executing a Delete() via GORM, the AfterDelete hook will fire.  What the AfterDelete hook receives is the struct that was in the Delete().
If a Where("id=?", 10).Delete(&struct{}) clause is used or an ID is populated via Delete(&struct{}, 10) then the AfterDelete receives an empty struct.

The documentation on gorm.io should reflect what AfterDelete receives so that developers can use AfterDelete appropriately.

- Use Case 1 - Struct populated with ID
  - AfterDelete is called ONCE and receives the struct with ID (and other fields if provided), UpdatedAt, and DeletedAt populated
  - Test structdelete shows this
 - Use Case 2 - Struct without ID, and list of ID(s) provided in delete conditions
   - AfterDelete is called ONCE and receives the struct without ID (but other fields if provided), UpdatedAt, and DeletedAt populated
   - Test structdeletebyid shows this
 - Use Case 3 - Empty Struct, Delete using Where clause
   - AfterDelete is called ONCE and receives a struct with UpdatedAt, and DeletedAt populated
   - Tests singledeletebyid, singledelete and bulkdelete shows these
