### PR TITLE
Repro batch error for sqlite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module gorm.io/playground
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 
 require (
 	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.10
-	gorm.io/driver/sqlite v1.5.6
+	gorm.io/driver/postgres v1.5.11
+	gorm.io/driver/sqlite v1.5.7
 	gorm.io/driver/sqlserver v1.5.4
 	gorm.io/gen v0.3.26
 	gorm.io/gorm v1.25.12
@@ -15,25 +15,25 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.8.1 // indirect
+	github.com/go-sql-driver/mysql v1.9.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/pgx/v5 v5.7.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
-	github.com/microsoft/go-mssqldb v1.7.2 // indirect
-	golang.org/x/crypto v0.29.0 // indirect
-	golang.org/x/mod v0.22.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
-	golang.org/x/sys v0.27.0 // indirect
-	golang.org/x/text v0.20.0 // indirect
-	golang.org/x/tools v0.27.0 // indirect
-	gorm.io/datatypes v1.2.4 // indirect
+	github.com/microsoft/go-mssqldb v1.8.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/mod v0.24.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/tools v0.31.0 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.5.3 // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,31 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
-
-	DB.Create(&user)
+	users := []map[string]any{
+		{"Name": "FOOBAR"},
+	}
+	// Without batching all works fine
+	// err := DB.Model(&User{}).Clauses(clause.OnConflict{DoNothing: true}).Create(&users).Error
+	// if err != nil {
+	// 	t.Errorf("Failed, got error: %v", err)
+	// }
+	// With bathing it doesn't
+	err := DB.Model(&User{}).Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&users, 100).Error
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.First(&result).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When using the batch API &  Update, it panics. It shouldn't 

For me the difference come from this line: 

https://github.com/go-gorm/gorm/blob/master/finisher_api.go#L48

Due to this `subtx.Statement.Dest` will be a `[]map[string]interface`, while if we use the non batching API, it'll be a `*[]map[string]interface` (ie the type passed as parameter to Update()

```
❯ ./test.sh
git clone --depth 1 -b master https://github.com/go-gorm/gorm.git
Cloning into 'gorm'...
remote: Enumerating objects: 183, done.
remote: Counting objects: 100% (183/183), done.
remote: Compressing objects: 100% (177/177), done.
remote: Total 183 (delta 11), reused 53 (delta 4), pack-reused 0 (from 0)
Receiving objects: 100% (183/183), 239.48 KiB | 3.24 MiB/s, done.
Resolving deltas: 100% (11/11), done.
testing sqlite...
2025/03/11 13:48:37 testing sqlite3...
=== RUN   TestGORM
--- FAIL: TestGORM (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x95a44d]

goroutine 24 [running]:
testing.tRunner.func1.2({0xee35a0, 0x15c2200})
	/home/aurelien/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/testing/testing.go:1632 +0x3fc
testing.tRunner.func1()
	/home/aurelien/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/testing/testing.go:1635 +0x6b6
panic({0xee35a0?, 0x15c2200?})
	/home/aurelien/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/runtime/panic.go:785 +0x132
gorm.io/gorm.Scan({0x10cde80, 0xc000223180}, 0xc0004381b0, 0x6)
	/home/aurelien/code/experiments/gorm-playground/gorm/scan.go:312 +0x1a6d
gorm.io/gorm/callbacks.RegisterDefaultCallbacks.Create.func3(0xc0004381b0)
	/home/aurelien/code/experiments/gorm-playground/gorm/callbacks/create.go:91 +0xb4a
gorm.io/gorm.(*processor).Execute(0xc0002d0960, 0xc0004381b0)
	/home/aurelien/code/experiments/gorm-playground/gorm/callbacks.go:130 +0xa78
gorm.io/gorm.(*DB).CreateInBatches.func1(0xc000438180)
	/home/aurelien/code/experiments/gorm-playground/gorm/finisher_api.go:49 +0x25e
gorm.io/gorm.(*DB).CreateInBatches(0xc000438120, {0xea7920, 0xc000012fd8}, 0x64)
	/home/aurelien/code/experiments/gorm-playground/gorm/finisher_api.go:59 +0x2de
gorm.io/playground.TestGORM(0xc0000e96c0)
	/home/aurelien/code/experiments/gorm-playground/main_test.go:23 +0x2de
testing.tRunner(0xc0000e96c0, 0xff4110)
	/home/aurelien/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/testing/testing.go:1690 +0x227
created by testing.(*T).Run in goroutine 1
	/home/aurelien/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.3.linux-amd64/src/testing/testing.go:1743 +0x826
FAIL	gorm.io/playground	0.076s
FAIL```