### PR TITLE
decimal在 automigrate的时候无法正确同步

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,3 +18,13 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+func TestAutoMigrateDecimal(t *testing.T) {
+	err := DB.AutoMigrate(Change{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = DB.AutoMigrate(Change{})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/models.go
+++ b/models.go
@@ -58,3 +58,7 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Change struct {
+	RecID int64 `gorm:"column:recid;type:decimal(9,0);not null;autoIncrement:false" json:"recid"`
+}


### PR DESCRIPTION
## Explain your user case and expected results
type Change struct {
	RecID int64 `gorm:"column:recid;type:decimal(9,0);not null;autoIncrement:false" json:"recid"`
}
我使用这种结构的时候，每次自动同步，都会打印日志：

```
 ALTER TABLE `changes` MODIFY COLUMN `recid` decimal(9,0) NOT NULL  

```

