### PR TITLE
Update main_test.go

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"gorm.io/plugin/opentelemetry/tracing"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -10,7 +11,8 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
+	DB.Use(tracing.NewPlugin())
+	
 	DB.Create(&user)
 
 	var result User


### PR DESCRIPTION


Using db.Use(tracing.NewPlugin()) from "gorm.io/plugin/opentelemetry/tracing" breaks build (dependency no longer available)
