### PR TITLE
IDs of child table is invalid when update in MySQL

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &App{}, &Env{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
-	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.11
-	gorm.io/driver/sqlite v1.5.7
+	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.0
 	gorm.io/gen v0.3.27
 	gorm.io/gorm v1.30.0
@@ -26,10 +26,10 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
-	github.com/microsoft/go-mssqldb v1.8.1 // indirect
+	github.com/microsoft/go-mssqldb v1.8.2 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	gorm.io/datatypes v1.2.5 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,61 @@ package main
 
 import (
 	"testing"
+
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: mysql
+// __TEST_DRIVERS__: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	appInitial := &App{
+		Name: "foo",
+		Envs: []*Env{
+			{Key: "KEY1", Value: "value1"},
+		},
+	}
+	DB.Create(appInitial)
+	t.Logf("appInitial: %+v", appInitial)
+	for i, env := range appInitial.Envs {
+		t.Logf("  env[%d]: %+v", i, env)
+	}
 
-	DB.Create(&user)
+	appUpdated := &App{
+		ID:   appInitial.ID,
+		Name: "foo",
+		Envs: []*Env{
+			{Key: "KEY1", Value: "value1-updated"},
+			{Key: "KEY2", Value: "value2-added"},
+		},
+	}
+	DB.Session(&gorm.Session{FullSaveAssociations: true}).Updates(appUpdated)
+	t.Logf("appUpdated: %+v", appUpdated)
+	for i, env := range appUpdated.Envs {
+		t.Logf("  env[%d]: %+v", i, env)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	appFetched := &App{ID: appInitial.ID}
+	DB.Preload("Envs").First(appFetched)
+	t.Logf("appFetched: %+v", appFetched)
+	for i, env := range appFetched.Envs {
+		t.Logf("  env[%d]: %+v", i, env)
+	}
+
+	for i := range appFetched.Envs {
+		envFetched := appFetched.Envs[i]
+		envUpdated := appUpdated.Envs[i]
+
+		if envFetched.Key != envUpdated.Key {
+			t.Errorf("Expected env key %s, got %s", envFetched.Key, envUpdated.Key)
+		}
+		if envFetched.Value != envUpdated.Value {
+			t.Errorf("Expected env value %s, got %s", envFetched.Value, envUpdated.Value)
+		}
+		if envFetched.ID != envUpdated.ID {
+			t.Errorf("Expected env ID %d, got %d", envFetched.ID, envUpdated.ID)
+		}
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,17 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type App struct {
+	ID   int
+	Name string
+
+	Envs []*Env `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+}
+
+type Env struct {
+	ID    int
+	AppID int    `gorm:"uniqueIndex:idx_app_id_key"`
+	Key   string `gorm:"size:64; uniqueIndex:idx_app_id_key"`
+	Value string
+}


### PR DESCRIPTION
## Explain your user case and expected results

```
❯ GORM_DIALECT=mysql go test
2025/06/05 22:53:08 testing mysql...

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:21
[1.735ms] [rows:1] INSERT INTO `envs` (`app_id`,`key`,`value`) VALUES (1,'KEY1','value1') ON DUPLICATE KEY UPDATE `app_id`=VALUES(`app_id`)

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:21
[6.075ms] [rows:1] INSERT INTO `apps` (`name`) VALUES ('foo')

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:35
[1.140ms] [rows:3] INSERT INTO `envs` (`app_id`,`key`,`value`) VALUES (1,'KEY1','value1-updated'),(1,'KEY2','value2-added') ON DUPLICATE KEY UPDATE `app_id`=VALUES(`app_id`),`key`=VALUES(`key`),`value`=VALUES(`value`)

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:35
[4.826ms] [rows:0] UPDATE `apps` SET `name`='foo' WHERE `id` = 1

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:42
[0.941ms] [rows:2] SELECT * FROM `envs` WHERE `envs`.`app_id` = 1

2025/06/05 22:53:08 /Users/redacted/gorm-issue-report/main_test.go:42
[2.121ms] [rows:1] SELECT * FROM `apps` WHERE `apps`.`id` = 1 ORDER BY `apps`.`id` LIMIT 1
--- FAIL: TestGORM (0.01s)
    main_test.go:22: appInitial: &{ID:1 Name:foo Envs:[0x1400037b2f0]}
    main_test.go:24:   env[0]: &{ID:1 AppID:1 Key:KEY1 Value:value1}
    main_test.go:36: appUpdated: &{ID:1 Name:foo Envs:[0x140002a3e90 0x140002a3ec0]}
    main_test.go:38:   env[0]: &{ID:2 AppID:1 Key:KEY1 Value:value1-updated}
    main_test.go:38:   env[1]: &{ID:3 AppID:1 Key:KEY2 Value:value2-added}
    main_test.go:43: appFetched: &{ID:1 Name:foo Envs:[0x140002f28a0 0x140002f2930]}
    main_test.go:45:   env[0]: &{ID:1 AppID:1 Key:KEY1 Value:value1-updated}
    main_test.go:45:   env[1]: &{ID:2 AppID:1 Key:KEY2 Value:value2-added}
    main_test.go:59: Expected env ID 1, got 2
    main_test.go:59: Expected env ID 2, got 3
FAIL
exit status 1
FAIL	gorm.io/playground	1.132s
```

# Environment

- MySQL

# Symptom

IDs after `Update()` is not same as those saved in database.
As you see, IDs in database is `1, 2` but IDs of updated results are `2, 3`.

```
appUpdated: &{ID:1 Name:foo Envs:[0x140002a3e90 0x140002a3ec0]}
  env[0]: &{ID:2 AppID:1 Key:KEY1 Value:value1-updated}
  env[1]: &{ID:3 AppID:1 Key:KEY2 Value:value2-added}
appFetched: &{ID:1 Name:foo Envs:[0x140002f28a0 0x140002f2930]}
  env[0]: &{ID:1 AppID:1 Key:KEY1 Value:value1-updated}
  env[1]: &{ID:2 AppID:1 Key:KEY2 Value:value2-added}
```
