### PR TITLE
Statement.Changed can't work on a new custom struct

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,7 +83,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}, &Man{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,24 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
 
 func main() {
 	fmt.Println("vim-go")
+}
+
+func (m *Man) update(data interface{}) error {
+	return DB.Set("data", data).Model(m).Where("id = ?", m.Id).Updates(data).Error
+}
+
+func (m *Man) BeforeUpdate(tx *gorm.DB) error {
+	if !tx.Statement.Changed("age") {
+		fmt.Println("no")
+		return nil
+	}
+	fmt.Println("yes")
+	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,12 +9,40 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	man := Man{Id: 1, Name: "Man1", Age: 1}
+	DB.Create(&man)
 
-	DB.Create(&user)
+	// update data
+	idx := Man{Id: 1}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	change1 := Man{
+		Age: 10,
+	}
+	change2 := map[string]interface{}{
+		"age": 20,
+	}
+	change3 := struct {
+		Age int
+	}{Age: 30}
+
+	_, _, _ = change1, change2, change3
+	var err error
+
+	// change1 -> yes
+	err = idx.update(change1)
+	if err != nil {
+		return
+	}
+
+	// change2 -> yes
+	err = idx.update(change2)
+	if err != nil {
+		return
+	}
+
+	// change3 -> panic: reflect: Field index out of range
+	err = idx.update(change3)
+	if err != nil {
+		return
 	}
 }

--- a/models.go
+++ b/models.go
@@ -58,3 +58,9 @@ type Language struct {
 	Code string `gorm:"primarykey"`
 	Name string
 }
+
+type Man struct {
+	Id   int `gorm:"primaryKey"`
+	Name string
+	Age  int
+}


### PR DESCRIPTION
## Explain your user case and expected results

When hook `tx.Statement.Changed` on func `BeforeUpdate` catch `"age"`

create a struct, and method.

```go
func (m *Man) update(data interface{}) error {
	return DB.Set("data", data).Model(m).Where("id = ?", m.Id).Updates(data).Error
}

func (m *Man) BeforeUpdate(tx *gorm.DB) error {
	if !tx.Statement.Changed("age") {
		fmt.Println("no")
		return nil
	}
	fmt.Println("yes")
	return nil
}
```

this struct have `Age`, so `tx.Statement.Changed("age")` should got `yes`, but got `panic: reflect: Field index out of range`
```go
	var change3 = struct {
		Age int
	}{Age: 30}

	// change3 -> panic: reflect: Field index out of range
	err := idx.update(change3)
	if err != nil {
		return
	}
```