### PR TITLE
Breaking change in gorm v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
-	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.11
-	gorm.io/driver/sqlite v1.5.7
+	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.0
 	gorm.io/gen v0.3.27
 	gorm.io/gorm v1.30.0
@@ -15,7 +15,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -26,12 +26,12 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
-	github.com/microsoft/go-mssqldb v1.8.1 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.33.0 // indirect
+	github.com/microsoft/go-mssqldb v1.8.2 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
+	golang.org/x/tools v0.34.0 // indirect
 	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.0 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"testing"
 )
 
@@ -10,11 +11,16 @@ import (
 
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
-
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	account := Account{UserID: sql.NullInt64{Int64: int64(user.ID), Valid: true}, Number: "test"}
+	DB.Create(&account)
+
+	var row User
+
+	result := DB.Joins("LEFT JOIN accounts ON accounts.user_id = users.id").Where(map[string]any{"accounts.number": "test"}).Debug().First(&row)
+
+	if result.Error != nil {
+		t.Error(result.Error)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

When updating from v1.5.7 to v1.6.0 there is a breaking change related to where conditions and joins.

Earlier this worked for these versions
```
- gorm.io/driver/mysql v1.5.7
- gorm.io/driver/postgres v1.5.11
- gorm.io/driver/sqlite v1.5.7
- gorm.io/gorm v1.25.12
- gorm.io/plugin/dbresolver v1.5.3
```

When updating to 1.6.0 it breaks. The change in the where condition goes from 
```
accounts.number = "test"
``` 

to 

```
`users`.`accounts`.`number` = "test"
```

Resulting in an error: `no such column: users.accounts.number`