### PR TITLE
Preload with a scoped OR condition generates incorrect SQL WHERE clause

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,11 +83,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&Dataset{}, &DatasetColumn{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 
-	DB.Migrator().DropTable("user_friends", "user_speaks")
+	DB.Migrator().DropTable("datasets", "dataset_columns")
 
 	if err = DB.Migrator().DropTable(allModels...); err != nil {
 		log.Printf("Failed to drop table, got error %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
-	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.11
-	gorm.io/driver/sqlite v1.5.7
+	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.0
 	gorm.io/gen v0.3.27
 	gorm.io/gorm v1.30.0
@@ -15,7 +15,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -26,15 +26,16 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
-	github.com/microsoft/go-mssqldb v1.8.1 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.33.0 // indirect
+	github.com/microsoft/go-mssqldb v1.9.2 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
+	golang.org/x/tools v0.34.0 // indirect
 	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.0 // indirect
+	gorm.io/plugin/soft_delete v1.2.1 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main.go
+++ b/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "fmt"
+import "gorm.io/gorm"
 
-func main() {
-	fmt.Println("vim-go")
+// Preload helper to create a scope for preloading associations.
+func Preload(query string, args ...interface{}) func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Preload(query, args...)
+	}
+}
+
+// QueryColumnsFilter provides a scope to filter columns.
+// This is the scope containing the OR condition that triggers the bug.
+// It should select columns that are either system columns OR are not hidden.
+func QueryColumnsFilter() func(db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		// The condition is: (is_system = true OR is_hidden = false)
+		return db.Where(db.Where("is_system = ?", true).Or("is_hidden = ?", false))
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,20 +1,79 @@
 package main
 
 import (
+	"slices"
 	"testing"
 )
 
-// GORM_REPO: https://github.com/go-gorm/gorm.git
-// GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+func TestPreloadWithOrCondition(t *testing.T) {
+	// --- Setup ---
+	DB.Migrator().DropTable(&Dataset{}, &DatasetColumn{})
+	if err := DB.AutoMigrate(&Dataset{}, &DatasetColumn{}); err != nil {
+		t.Fatalf("Failed to migrate database: %v", err)
+	}
 
-func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	// Create sample data for the target dataset
+	dataset := Dataset{
+		Name: "My Dataset",
+		Columns: []*DatasetColumn{
+			{Name: "System Column 1", IsSystem: true, IsHidden: false},       // Should be loaded
+			{Name: "Visible Column 2", IsSystem: false, IsHidden: false},     // Should be loaded
+			{Name: "Hidden System Column 3", IsSystem: true, IsHidden: true}, // Should be loaded
+		},
+	}
+	if err := DB.Create(&dataset).Error; err != nil {
+		t.Fatalf("Failed to create sample data: %v", err)
+	}
 
-	DB.Create(&user)
+	dataset2 := Dataset{
+		Name: "My Dataset 2",
+	}
+	if err := DB.Create(&dataset2).Error; err != nil {
+		t.Fatalf("Failed to create sample data: %v", err)
+	}
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	// Create a column that SHOULD NOT be loaded but will be by the buggy query
+	// It belongs to a different dataset but is visible.
+	// The correct query would filter by dataset_id first.
+	// The buggy query will include it because `is_hidden = false` is true.
+	rogueColumn := DatasetColumn{
+		Name:      "Rogue Visible Column",
+		DatasetID: dataset2.ID, // Different dataset
+		IsSystem:  false,
+		IsHidden:  false,
+	}
+	if err := DB.Create(&rogueColumn).Error; err != nil {
+		t.Fatalf("Failed to create rogue column: %v", err)
+	}
+
+	// --- Reproduce the Bug ---
+	var loadedDataset Dataset
+	err := DB.Model(&Dataset{}).
+		Where(&Dataset{ID: dataset.ID}).
+		Scopes(Preload("Columns", QueryColumnsFilter())).
+		First(&loadedDataset).Error
+
+	if err != nil {
+		t.Fatalf("Error during preload: %v", err)
+	}
+
+	// --- Assertion ---
+	var loadedNames []string
+	for _, col := range loadedDataset.Columns {
+		loadedNames = append(loadedNames, col.Name)
+	}
+
+	// This is the key assertion that will now fail.
+	// The buggy query will incorrectly load "Rogue Visible Column"
+	// because the OR condition bypasses the dataset_id check.
+	if slices.Contains(loadedNames, "Rogue Visible Column") {
+		t.Errorf("FATAL BUG: Loaded a column from another dataset ('Rogue Visible Column') due to incorrect WHERE clause logic")
+	}
+
+	expectedCount := 3
+	if len(loadedDataset.Columns) != expectedCount {
+		// This assertion might also fail now, as the count will be 4 instead of 3.
+		t.Errorf("Expected to load %d columns for dataset %d, but got %d. Loaded names: %v",
+			expectedCount, dataset.ID, len(loadedNames), loadedNames)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,22 @@
 package main
 
 import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
+	"gorm.io/plugin/soft_delete"
 )
 
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+// --- Models ---
+type Dataset struct {
+	ID      uint   `gorm:"primaryKey"`
+	Name    string `gorm:"comment:Name;size:30;index;not null;"`
+	Columns []*DatasetColumn
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
-}
-
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type DatasetColumn struct {
+	ID        uint                  `gorm:"primaryKey"`
+	DatasetID uint
+	Dataset   Dataset
+	DeletedAt soft_delete.DeletedAt `gorm:"comment:删除时间;uniqueIndex:idx_dc_ddn;not null;"`
+	Name      string                `gorm:"comment:名称;size:30;uniqueIndex:idx_dc_ddn;not null;"`
+	IsSystem  bool                  `gorm:"comment:是否系统列;not null;default:false;"`
+	IsHidden  bool                  `gorm:"comment:是否隐藏;not null;"`
 }


### PR DESCRIPTION
## Explain your user case and expected results

Since upgrading to Gorm v1.30.0, Preload with a custom scope that includes an OR condition generates a malformed SQL WHERE clause. The conditions from the scope are duplicated and incorrectly grouped with the foreign key condition, leading to unexpected query results.