### PR TITLE
bug: the version 1.30.0 is not compatible with older version when using this code

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -17,4 +18,21 @@ func TestGORM(t *testing.T) {
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
+}
+
+func TestGORM(t *testing.T) {
+	user := User{Name: "jinzhu", IsDeleted: false}
+	DB = DB.Debug()
+
+	DB.Create(&user)
+
+	var user1 User
+	basicCondition := map[string]string{
+		fmt.Sprintf("%s.is_deleted", "users"): "false",
+	}
+	err := DB.Table("users").Where(basicCondition).Find(&user1)
+	if err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	fmt.Printf("User: %v\n", user)
 }

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	IsDeleted bool
 }
 
 type Account struct {


### PR DESCRIPTION
## Explain your user case and expected results

When I run this case, I need to make the SQL statement like below:
```sql
SELECT * FROM `users` WHERE `users`.`is_deleted` = "false" AND `users`.`deleted_at` IS NULL
```

Not this:
```sql
SELECT * FROM `users` WHERE `users`.`users`.`is_deleted` = "false" AND `users`.`deleted_at` IS NULL
```

The error occured when I upgrade the gorm version from v1.25.9 to v.1.30.0. The newer should be compatible with the older version.