### PR TITLE
Repro for postgres deep nested joins

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
 )
 
 var DB *gorm.DB
@@ -55,7 +56,11 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm host=localhost dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{
+				IdentifierMaxLength: 63,
+			},
+		})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;
@@ -83,7 +88,7 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 
 func RunMigrations() {
 	var err error
-	allModels := []interface{}{&User{}, &Account{}, &Pet{}, &Company{}, &Toy{}, &Language{}}
+	allModels := []interface{}{&LanguageInformation{}, &CompanyInformation{}, &Person{}}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(allModels), func(i, j int) { allModels[i], allModels[j] = allModels[j], allModels[i] })
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
-	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.11
-	gorm.io/driver/sqlite v1.5.7
+	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.0
 	gorm.io/gen v0.3.27
 	gorm.io/gorm v1.30.0
@@ -15,7 +15,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -26,13 +26,13 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
-	github.com/microsoft/go-mssqldb v1.8.1 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.33.0 // indirect
-	gorm.io/datatypes v1.2.5 // indirect
+	github.com/microsoft/go-mssqldb v1.9.2 // indirect
+	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/mod v0.26.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+	golang.org/x/tools v0.35.0 // indirect
+	gorm.io/datatypes v1.2.6 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.0 // indirect
 )

--- a/main_test.go
+++ b/main_test.go
@@ -6,15 +6,73 @@ import (
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite, mysql, postgres
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	languageEnglish := LanguageInformation{
+		InternationalCode: "en-us",
+		Name:              "English",
+	}
+	DB.Create(&languageEnglish)
 
-	DB.Create(&user)
+	company1 := CompanyInformation{
+		Name:                       "Company 1",
+		PreferredCompanyLanguageID: &languageEnglish.ID,
+	}
+	DB.Create(&company1)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	ceoPerson := Person{
+		FirstAndLastName:  "John Smith",
+		CurrentEmployerID: &company1.ID,
+	}
+	DB.Create(&ceoPerson)
+
+	var result Person
+	err := DB.Model(&Person{}).
+		Joins("CurrentEmployerInformation").
+		Joins("CurrentEmployerInformation.PreferredCompanyLanguage").
+		Limit(1).
+		First(&result).
+		Error
+
+	if err != nil {
+		t.Fatalf("Got DB error %v", err)
+	}
+
+	// All these should pass
+	if result.FirstAndLastName != "John Smith" {
+		t.Fatal("FirstAndLastName should be John Smith")
+	}
+	if result.CurrentEmployerInformation == nil {
+		t.Fatal("CurrentEmployerInformation should not be nil")
+	}
+
+	if result.CurrentEmployerInformation.Name != "Company 1" {
+		t.Fatal("CurrentEmployerInformation.Name should be Company 1")
+	}
+
+	if result.CurrentEmployerInformation.PreferredCompanyLanguage == nil {
+		t.Fatal("CurrentEmployerInformation.PreferredCompanyLanguage should not be nil")
+	}
+	if result.CurrentEmployerInformation.PreferredCompanyLanguage.Name != "English" {
+		t.Fatal("CurrentEmployerInformation.PreferredCompanyLanguage should be English")
+	}
+
+	/*
+		This is the one that is demonstrating the specific bug with Postgres:
+		The generated SQL query for this column is:
+		`CurrentEmployerInformation__PreferredCompanyLanguage`.`international_code` AS `CurrentEmployerInformation__PreferredCompanyLanguage__international_code`,
+
+		CurrentEmployerInformation__PreferredCompanyLanguage__international_code is larger than 63 characters long. Postgres
+		accepts this in the query correctly, but returns a truncated identifier for this column that is 63 characters long.
+
+		Gorm does not map the truncated column identifier to the intended column, leaving it empty.
+		Note that this happens silently; other columns are still populated.
+
+		Using the `NamingStrategy` with max length = 63 does not affect the identifier length in query building, and
+		thus does not address this issue.
+	*/
+	if result.CurrentEmployerInformation.PreferredCompanyLanguage.InternationalCode != "en-us" {
+		t.Fatalf("CurrentEmployerInformation.PreferredCompanyLanguage should be en-us, but was `%v`", result.CurrentEmployerInformation.PreferredCompanyLanguage.InternationalCode)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -1,60 +1,21 @@
 package main
 
-import (
-	"database/sql"
-	"time"
-
-	"gorm.io/gorm"
-)
-
-// User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
-// He works in a Company (belongs to), he has a Manager (belongs to - single-table), and also managed a Team (has many - single-table)
-// He speaks many languages (many to many) and has many friends (many to many - single-table)
-// His pet also has one Toy (has one - polymorphic)
-type User struct {
-	gorm.Model
-	Name      string
-	Age       uint
-	Birthday  *time.Time
-	Account   Account
-	Pets      []*Pet
-	Toys      []Toy `gorm:"polymorphic:Owner"`
-	CompanyID *int
-	Company   Company
-	ManagerID *uint
-	Manager   *User
-	Team      []User     `gorm:"foreignkey:ManagerID"`
-	Languages []Language `gorm:"many2many:UserSpeak"`
-	Friends   []*User    `gorm:"many2many:user_friends"`
-	Active    bool
+type Person struct {
+	ID                         int64 `gorm:"primary_key"`
+	FirstAndLastName           string
+	CurrentEmployerID          *int64
+	CurrentEmployerInformation *CompanyInformation `gorm:"foreignKey:CurrentEmployerID"`
 }
 
-type Account struct {
-	gorm.Model
-	UserID sql.NullInt64
-	Number string
+type CompanyInformation struct {
+	ID                         int64 `gorm:"primary_key"`
+	Name                       string
+	PreferredCompanyLanguageID *int64
+	PreferredCompanyLanguage   *LanguageInformation `gorm:"foreignKey:PreferredCompanyLanguageID"`
 }
 
-type Pet struct {
-	gorm.Model
-	UserID *uint
-	Name   string
-	Toy    Toy `gorm:"polymorphic:Owner;"`
-}
-
-type Toy struct {
-	gorm.Model
-	Name      string
-	OwnerID   string
-	OwnerType string
-}
-
-type Company struct {
-	ID   int
-	Name string
-}
-
-type Language struct {
-	Code string `gorm:"primarykey"`
-	Name string
+type LanguageInformation struct {
+	ID                int64 `gorm:"primarykey"`
+	InternationalCode string
+	Name              string
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-dialects=("sqlite" "mysql" "postgres" "sqlserver")
+dialects=("sqlite" "mysql" "postgres")
 
 if [ "$GORM_ENABLE_CACHE" = "" ]
 then


### PR DESCRIPTION
## Explain your user case and expected results

### Context

In Postgres, query column identifiers are subject to Postgres' 63 character limit. While Postgres will accept queries with identifiers that are longer than this limit, the query response will truncate the identifier to the 63 character limit.

This has an impact on Gorm when it attempts to map a query response back into a struct.

### Test Case

I have added a test case with a doubly nested entity. The test case expects the `international_code` field to be populated following the join query, but it is `""`. This is a silent error.


This happens because the generated SQL query to retrieve this column is:
```SQL
`CurrentEmployerInformation__PreferredCompanyLanguage`.`international_code` AS `CurrentEmployerInformation__PreferredCompanyLanguage__international_code`
```

`CurrentEmployerInformation__PreferredCompanyLanguage__international_code` is larger than 63 characters long. 

Postgres accepts this in the query correctly, but returns a truncated identifier for this column that is 63 characters long. Because of the truncation, Gorm cannot map the data to its intended column, leaving it empty.

Note that this happens silently; other columns are still populated. Using the `NamingStrategy` with max length = 63 does not affect the identifier length in query building, and thus does not address this issue.