### PR TITLE
bug: using .Order in a scope is not compatible with DB.Count()

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2,19 +2,36 @@ package main
 
 import (
 	"testing"
+	"gorm.io/gorm"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
+
+func OrderByScope(db *gorm.DB) *gorm.DB {
+	return db.Order("name desc")
+}
+
 func TestGORM(t *testing.T) {
 	user := User{Name: "jinzhu"}
 
 	DB.Create(&user)
 
-	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
-	}
+	var count int64
+
+	t.Run("ORDER BY + Count() works fine normally", func(t *testing.T) {
+		if err := DB.Model(&User{}).Order("name desc").Count(&count).Error; err != nil {
+			t.Errorf("Failed in normal .Order(), got error: %v", err)
+		}
+		t.Logf("Count: %d", count)
+	})
+
+	t.Run("ORDER BY in scope + Count() fails", func(t *testing.T) {
+		if err := DB.Model(&User{}).Scopes(OrderByScope).Count(&count).Error; err != nil {
+			t.Errorf("Failed with .Order() in a scope, got error: %v", err)
+		}
+		t.Logf("Count: %d", count)
+	})
 }


### PR DESCRIPTION
## Explain your user case and expected results
When you add an `Order()` statement to a `Count()` query, then the code runs fine in postgres. However, when you have the `Order()` statement in a scope, and add it to a `Count()` query, then it fails

```
GORM_DIALECT=postgres go test                                                 
2025/07/14 16:52:37 testing postgres...

2025/07/14 16:52:37 /Users/ben/code/gorm-playground/main_test.go:20
[1.413ms] [rows:1] INSERT INTO "users" ("created_at","updated_at","deleted_at","name","age","birthday","company_id","manager_id","active") VALUES ('2025-07-14 16:52:37.439','2025-07-14 16:52:37.439',NULL,'jinzhu',0,NULL,NULL,NULL,false) RETURNING "id"

2025/07/14 16:52:37 /Users/ben/code/gorm-playground/main_test.go:25
[0.543ms] [rows:1] SELECT count(*) FROM "users" WHERE "users"."deleted_at" IS NULL

2025/07/14 16:52:37 /Users/ben/code/gorm-playground/main_test.go:32 ERROR: column "users.name" must appear in the GROUP BY clause or be used in an aggregate function (SQLSTATE 42803)
[0.402ms] [rows:0] SELECT count(*) FROM "users" WHERE "users"."deleted_at" IS NULL ORDER BY name desc
--- FAIL: TestGORM (0.00s)
    --- FAIL: TestGORM/ORDER_BY_in_scope_+_Count()_fails (0.00s)
        main_test.go:33: Failed with .Order() in a scope, got error: ERROR: column "users.name" must appear in the GROUP BY clause or be used in an aggregate function (SQLSTATE 42803)
        main_test.go:35: Count: 0
FAIL
exit status 1
FAIL	gorm.io/playground	0.050s
```
(seems to work fine for me in mysql and mssql)