### PR TITLE
test: Reproduce incorrect type inference for self-referential UUID FK (PostgreSQL)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
-	gorm.io/driver/mysql v1.5.7
-	gorm.io/driver/postgres v1.5.11
-	gorm.io/driver/sqlite v1.5.7
+	github.com/google/uuid v1.6.0
+	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/driver/sqlserver v1.6.0
 	gorm.io/gen v0.3.27
 	gorm.io/gorm v1.30.0
@@ -15,10 +16,9 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.5 // indirect
@@ -26,13 +26,13 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect
-	github.com/microsoft/go-mssqldb v1.8.1 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
-	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.33.0 // indirect
-	gorm.io/datatypes v1.2.5 // indirect
+	github.com/microsoft/go-mssqldb v1.9.2 // indirect
+	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/mod v0.26.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
+	golang.org/x/tools v0.35.0 // indirect
+	gorm.io/datatypes v1.2.6 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.0 // indirect
 )

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -12,7 +13,9 @@ import (
 // He speaks many languages (many to many) and has many friends (many to many - single-table)
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
-	gorm.Model
+	// Replaced default ID with UUID.
+	ID uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+
 	Name      string
 	Age       uint
 	Birthday  *time.Time
@@ -27,6 +30,10 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+
+	// Add self referential UUID foreign key.
+	CreatedBy uuid.UUID `gorm:"type:uuid;not null"`
+	Creator   *User     `gorm:"foreignKey:CreatedBy;references:ID"`
 }
 
 type Account struct {


### PR DESCRIPTION
This PR adds a failing test case to reproduce a bug where a self-referential belongs to relationship with a UUID foreign key is incorrectly migrated as `bigint` instead of `uuid` for `PostgreSQL` databases.

The test defines a User struct with the problematic relationship and runs `AutoMigrate`. The test will fail because the generated DDL has the wrong column type for the foreign key.

This test is for issue # in the main go-gorm/gorm repository.