### PR TITLE
bug: unable to use returning for CreateInBatches

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"gorm.io/gorm/clause"
 	"testing"
 )
 
@@ -9,12 +10,19 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	users := []User{
+		{Name: "jinzhu", Age: 18},
+		{Name: "jinzhu1", Age: 18},
+	}
 
-	DB.Create(&user)
+	DB.Model(&users).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"age", "name"}),
+		}, clause.Returning{}).CreateInBatches(&users, len(users))
 
 	var result User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	if err := DB.First(&result, users[0].ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -13,7 +13,7 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
+	Name      string `gorm:"unique"`
 	Age       uint
 	Birthday  *time.Time
 	Account   Account


### PR DESCRIPTION
## Explain your user case and expected results
When using `CreateInBatches` with `ON CONFLICT` in conjunction with `RETURNING`.

1. With `gorm:"unique"`, the application will panic with `reflect: reflect.Value.SetLen using unaddressable value`.
2. Without `gorm:"unique"` the statement will run successfully, but the ID is not updated to the input object.