### PR TITLE
version 1.30.1 breaks gormschema/atlas migrate diff over 1.30.0 / Issue #7542

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
+	ariga.io/atlas-provider-gorm v0.5.3
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/driver/postgres v1.5.11
 	gorm.io/driver/sqlite v1.5.7
@@ -14,6 +15,7 @@ require (
 )
 
 require (
+	ariga.io/atlas-go-sdk v0.7.2 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
+
+	"ariga.io/atlas-provider-gorm/gormschema"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +20,18 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestDBMigrationGeneration(t *testing.T) {
+	dialect := os.Getenv("GORM_DIALECT")
+	stmts, err := gormschema.New(dialect).Load(&Account{})
+
+	if err != nil {
+		t.Errorf("error loading gorm schema: %v", err)
+	}
+
+	if !strings.Contains(stmts, "CREATE TABLE") {
+		t.Errorf(`"CREATE TABLE" not found in generated statements: %s`, stmts)
 	}
 }


### PR DESCRIPTION
Since v1.30.1, the migration generation for Atlas fails. Instead of `CREATE TABLE` statements, a bunch of `ALTER TABLE` statements are output. This results in an invalid script that tries to alter non-existing tables.

### Expected behavior
This is what the generated script should look like for the `Account` model
```sql
CREATE TABLE `accounts` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`updated_at` datetime,`deleted_at` datetime,`user_id` integer,`number` text);
CREATE INDEX `idx_accounts_deleted_at` ON `accounts`(`deleted_at`);
```

### Actual behavior
This is what is generated for the `Account` model
```sql
ALTER TABLE `accounts` ADD `id` integer PRIMARY KEY AUTOINCREMENT;
ALTER TABLE `accounts` ADD `created_at` datetime;
ALTER TABLE `accounts` ADD `updated_at` datetime;
ALTER TABLE `accounts` ADD `deleted_at` datetime;
ALTER TABLE `accounts` ADD `user_id` integer;
ALTER TABLE `accounts` ADD `number` text;
CREATE INDEX `idx_accounts_deleted_at` ON `accounts`(`deleted_at`);
```