### PR TITLE
test: add a case to demonstrate incorrect default value parsing in gorm

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"sync"
 	"testing"
+
+	"gorm.io/gorm/schema"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
@@ -16,5 +19,27 @@ func TestGORM(t *testing.T) {
 	var result User
 	if err := DB.First(&result, user.ID).Error; err != nil {
 		t.Errorf("Failed, got error: %v", err)
+	}
+}
+
+func TestParseJSONBFieldWithDefaultValue(t *testing.T) {
+	type Payload struct {
+		ID string
+	}
+	type Table struct {
+		ID      string  `gorm:"primaryKey;type:uuid"`
+		Payload Payload `gorm:"serializer:json;type:jsonb;default:'{}'"`
+		Str     string  `gorm:"default:'default'"`
+	}
+
+	s, err := schema.Parse(&Table{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("Unable to parse schema: %v", err)
+	}
+	if s.FieldsByDBName["payload"].DefaultValue != "{}" {
+		t.Errorf("Expected default value for payload to be `{}`, got %q", s.FieldsByDBName["payload"].DefaultValue)
+	}
+	if s.FieldsByDBName["str"].DefaultValue != "default" {
+		t.Errorf("Expected default value for str to be `default`, got %q", s.FieldsByDBName["str"].DefaultValue)
 	}
 }


### PR DESCRIPTION
## Explain your user case and expected results

User case: Set the default value of a JSONB field to `{}`

Expected result: GORM should parse the default value as `{}`

Actual result: GORM parsed the default value as `'{}'` (note the surrounding quotes)
