### PR TITLE
Repro generics join subquery using AS

### DIFF
--- a/generics_join_as_test.go
+++ b/generics_join_as_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestGenericsJoins(t *testing.T) {
+	dbg := DB.Session(&gorm.Session{DryRun: true})
+	db := gorm.G[User](dbg)
+
+	q := db.Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](dbg)).As("t"),
+		func(j gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
+			j.Where("?.\"name\" = ?", joinTable, "GenericsCompany")
+			return nil
+		},
+	).Where(map[string]any{"name": "GenericsJoins_2"})
+
+	stmt := &gorm.Statement{DB: dbg}
+	q.Build(stmt)
+
+	sql := stmt.SQL.String()
+	t.Logf("GENERATED SQL:\n%s", sql)
+}


### PR DESCRIPTION
Reproduce an issue when using generics `Joins` with subquery + `As("t")`

Generated SQL:
``` 
SELECT `users`.`id`,`users`.`created_at`,`users`.`updated_at`,`users`.`deleted_at`,`users`.`name`,`users`.`age`,`users`.`birthday`,`users`.`company_id`,`users`.`manager_id`,`users`.`active`,`t`.`id` AS `t__id`,`t`.`name` AS `t__name` 
FROM `users` 
LEFT JOIN (SELECT `companies`.`id`,`companies`.`name` FROM `companies` Company) AS `t` ON `t`."name" = ? WHERE `users`.`name` = ? AND `users`.`deleted_at` IS NULL
```
Oracle does not allow `AS` before table/subquery aliases, so this SQL is invalid.