### PR TITLE
Issue with quotes on unquoted alias name

### DIFF
--- a/alias-quote-test.go
+++ b/alias-quote-test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGenericsJoins(t *testing.T) {
+
+	DB.Migrator().CreateTable(User{})
+
+	user := User{Name: "Bob"}
+
+	DB.Create(&user)
+
+	var result User
+	if err := DB.Table("users u").Where("u.\"name\" = ?", "Bob").First(&result); err != nil {
+		fmt.Printf("failed to find user, got error: %v", err)
+	}
+	fmt.Printf("u.Name: %s u.ID: %d", result.Name, result.ID)
+}


### PR DESCRIPTION
## Explain your user case and expected results

**Testing with gorm-oracle**
When the alias name is provided unquoted, the alias name used when generating the query should be unquoted as well. 
For the below statement, 

`
DB.Table("users u").Where("u.\"name\" = ?", "Bob").First(&result);`

the generated query is:
`
SELECT * FROM users u WHERE u."name" = "Bob" AND `u`.`deleted_at` IS NULL ORDER BY `u`.`id` LIMIT 1`

it should be:
`
SELECT * FROM users u WHERE u."name" = "Bob" AND u.`deleted_at` IS NULL ORDER BY u.`id` LIMIT 1`

as oracle handles the quoted and unquoted indentifiers as separare entity.
