### PR TITLE
add case for #7580

### DIFF
--- a/bug_7580.go
+++ b/bug_7580.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestCompileError(t *testing.T) {
+	dbg := DB.Session(&gorm.Session{DryRun: true})
+	db := gorm.G[gorm.Model](dbg)
+
+	var _ gorm.ChainInterface[gorm.Model] = db
+	var _ gorm.Interface[gorm.Model] = db
+}


### PR DESCRIPTION
```Go
g := gorm.G[T](db)
var _ gorm.ChainInterface[T] = g
var _ gorm.Interface[T] = g
```

Should not produce a compiler error, but since 1.30.5 it does:

```
cannot use g (variable of interface type gorm.Interface[T]) as gorm.ChainInterface[T] value in variable declaration: gorm.Interface[T] does not implement gorm.ChainInterface[T] (missing method Count)
cannot use g (variable of interface type gorm.Interface[T]) as gorm.ChainInterface[T] value in struct literal: gorm.Interface[T] does not implement gorm.ChainInterface[T] (missing method Count)
```

Testing with 1.30.3 the code compiles, as expected.