### PR TITLE
`Model(A).FindInBatches(B)` cause `panic: reflect: Field index out of range`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,41 +1,34 @@
 module gorm.io/playground
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.24.12
 
 require (
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
-	gorm.io/driver/sqlserver v1.6.1
-	gorm.io/gorm v1.30.1
+	gorm.io/driver/sqlserver v1.6.3
+	gorm.io/gorm v1.31.1
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.5 // indirect
+	github.com/jackc/pgx/v5 v5.8.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/microsoft/go-mssqldb v1.9.2 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
-	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/tools v0.36.0 // indirect
-	gorm.io/cmd/gorm v0.1.1-0.20250825094947-30e7d4fa1f1f // indirect
-	gorm.io/datatypes v1.2.5 // indirect
-	gorm.io/hints v1.1.2 // indirect
-	gorm.io/plugin/dbresolver v1.6.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.37 // indirect
+	github.com/microsoft/go-mssqldb v1.9.7 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/go.mod
+++ b/go.mod
@@ -1,34 +1,41 @@
 module gorm.io/playground
 
-go 1.24.12
+go 1.24.0
+
+toolchain go1.24.3
 
 require (
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
-	gorm.io/driver/sqlserver v1.6.3
-	gorm.io/gorm v1.31.1
+	gorm.io/driver/sqlserver v1.6.1
+	gorm.io/gorm v1.30.1
 )
 
 require (
-	filippo.io/edwards25519 v1.2.0 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.8.0 // indirect
+	github.com/jackc/pgx/v5 v5.7.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.37 // indirect
-	github.com/microsoft/go-mssqldb v1.9.7 // indirect
-	github.com/shopspring/decimal v1.4.0 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/microsoft/go-mssqldb v1.9.2 // indirect
+	golang.org/x/crypto v0.41.0 // indirect
+	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
+	golang.org/x/mod v0.27.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/tools v0.36.0 // indirect
+	gorm.io/cmd/gorm v0.1.1-0.20250825094947-30e7d4fa1f1f // indirect
+	gorm.io/datatypes v1.2.5 // indirect
+	gorm.io/hints v1.1.2 // indirect
+	gorm.io/plugin/dbresolver v1.6.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm

--- a/main_test.go
+++ b/main_test.go
@@ -3,20 +3,39 @@ package main
 import (
 	"testing"
 
+	"gorm.io/gorm"
 	"gorm.io/playground/models"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite
+
+type UserExtended struct {
+	models.User
+	ExtraFoo int64
+}
 
 func TestGORM(t *testing.T) {
 	user := models.User{Name: "jinzhu"}
 
-	DB.Create(&user)
+	err := DB.Create(&user).Error
+	if err != nil {
+		t.Errorf("Create failed: %v", err)
+	}
 
-	var result models.User
-	if err := DB.First(&result, user.ID).Error; err != nil {
+	var results []UserExtended
+	err = DB.
+		// setting model for magic table name
+		Model(models.User{}).
+		Select(`*, 42 AS extra_foo`).
+		// taking results to different model with extra fields
+		FindInBatches(&results, 100, func(tx *gorm.DB, batch int) error {
+			// ...
+			return nil
+		}).
+		Error
+	if err != nil {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }


### PR DESCRIPTION
```go
type A struct {
	Foo int   // [0]
	Bar int   // [1]
	Baz int   // [2]
}
type B struct {
	A       // [0]
	Lol int // [1]
}

func _() {
	var chunk []B
	db.Model(A{})._.FindInBatches(&chunk, ...)
	//       ^^^                  ^^^^^^
	//        A                     B
}
```
Filling field `Baz` with index `2` discovered from `Model(A{})`, cause a panic, because field index `2` checked in type `B`.
> ```
> panic: reflect: Field index out of range
> ```
