### PR TITLE
test: add tests comparing clone vs DB where clauses

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -10,14 +10,61 @@ import (
 // GORM_BRANCH: master
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
-func TestGORM(t *testing.T) {
-	user := models.User{Name: "jinzhu"}
+func TestWithTX(t *testing.T) {
+	users := []models.User{
+		{Name: "jinzhu", Active: true},
+		{Name: "kaaris", Active: false},
+		{Name: "vald", Active: false},
+	}
 
-	DB.Create(&user)
+	DB.Create(users)
 
-	var result models.User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	tx := DB.Model(&models.User{})
+	tx = tx.Where("age = 0")
+
+	tx = tx.Where(
+		tx.Or("Name = ?", users[0].Name).
+			Or("Name = ?", users[1].Name),
+	)
+	// SELECT * FROM `users` WHERE (age = 0 OR Name = "jinzhu" OR Name = "kaaris" AND (age = 0 OR Name = "jinzhu" OR Name = "kaaris")) AND `users`.`deleted_at` IS NULL
+
+	dest := []models.User{}
+	results := tx.Find(&dest, nil)
+	if results.Error != nil {
+		t.Errorf("Failed, got error: %v", results)
+	}
+
+	if want, got := 2, len(dest); want != got {
+		t.Errorf("Failed to filter, want %d, got %d", want, got)
+	}
+}
+
+func TestWithDB(t *testing.T) {
+	users := []models.User{
+		{Name: "jinzhu", Active: true},
+		{Name: "kaaris", Active: false},
+		{Name: "vald", Active: false},
+	}
+
+	DB.Create(users)
+
+	tx := DB.Model(&models.User{})
+	tx = tx.Where("age = 0")
+
+	tx = tx.Where(
+		DB.Or("Name = ?", "jinzhu").
+			Or("Name = ?", "kaaris"),
+	)
+	// SELECT * FROM `users` WHERE (Name = "jinzhu" OR Name = "kaaris") AND `users`.`deleted_at` IS NULL
+
+	dest := []models.User{}
+	results := tx.Find(&dest, nil)
+	if results.Error != nil {
+		t.Errorf("Failed, got error: %v", results)
+	}
+
+	if want, got := 2, len(dest); want != got {
+		t.Errorf("Failed to filter, want %d, got %d", want, got)
 	}
 }
 


### PR DESCRIPTION
There is a difference in behavior when using the DB and a clone of the DB when running a query with "OR" conditions.
Tested with the postgres driver on a posrgreSQL 17.10