### PR TITLE
Generics association join with schema-qualified table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module gorm.io/playground
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.25.7
 
 require (
 	gorm.io/driver/mysql v1.6.0
@@ -32,7 +30,6 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
-	gorm.io/cmd/gorm v0.1.1-0.20250825094947-30e7d4fa1f1f // indirect
 	gorm.io/datatypes v1.2.5 // indirect
 	gorm.io/hints v1.1.2 // indirect
 	gorm.io/plugin/dbresolver v1.6.0 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -1,35 +1,83 @@
 package main
 
 import (
+	"context"
 	"testing"
 
-	"gorm.io/playground/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GORM_REPO: https://github.com/go-gorm/gorm.git
 // GORM_BRANCH: master
-// TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
+// TEST_DRIVERS: sqlite
 
-func TestGORM(t *testing.T) {
-	user := models.User{Name: "jinzhu"}
+type TenantOrder struct {
+	ID         int64 `gorm:"primaryKey"`
+	CustomerID int64
+	Customer   TenantCustomer `gorm:"foreignKey:CustomerID;references:ID"`
+}
 
-	DB.Create(&user)
+func (TenantOrder) TableName() string {
+	return "orders"
+}
 
-	var result models.User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+type TenantCustomer struct {
+	ID   int64 `gorm:"primaryKey"`
+	Name string
+}
+
+func (TenantCustomer) TableName() string {
+	return "customers"
+}
+
+func TestGenericsAssociationJoinWithSchemaQualifiedTable(t *testing.T) {
+	ctx := context.Background()
+
+	mustExec(t, `ATTACH DATABASE ':memory:' AS tenant_1`)
+	mustExec(t, `DROP TABLE IF EXISTS customers`)
+	mustExec(t, `DROP TABLE IF EXISTS tenant_1.customers`)
+	mustExec(t, `DROP TABLE IF EXISTS tenant_1.orders`)
+	mustExec(t, `CREATE TABLE customers (id integer PRIMARY KEY, name text NOT NULL)`)
+	mustExec(t, `CREATE TABLE tenant_1.customers (id integer PRIMARY KEY, name text NOT NULL)`)
+	mustExec(t, `CREATE TABLE tenant_1.orders (id integer PRIMARY KEY, customer_id integer NOT NULL)`)
+	mustExec(t, `INSERT INTO customers (id, name) VALUES (1, 'public customer')`)
+	mustExec(t, `INSERT INTO tenant_1.customers (id, name) VALUES (1, 'tenant customer')`)
+	mustExec(t, `INSERT INTO tenant_1.orders (id, customer_id) VALUES (1, 1)`)
+
+	got, err := gorm.G[TenantOrder](DB).
+		Table("tenant_1.orders").
+		Joins(clause.InnerJoin.Association("Customer"), nil).
+		First(ctx)
+	if err != nil {
+		t.Fatalf("association join failed: %v", err)
+	}
+	if got.Customer.Name != "tenant customer" {
+		t.Errorf("association join used the wrong physical table, got customer %q, want %q", got.Customer.Name, "tenant customer")
+	}
+
+	workaround, err := gorm.G[TenantOrder](DB).
+		Table("tenant_1.orders").
+		Joins(
+			clause.InnerJoin.AssociationFrom(
+				"Customer",
+				clause.Expr{SQL: "SELECT * FROM tenant_1.customers"},
+			).As("Customer"),
+			nil,
+		).
+		First(ctx)
+	if err != nil {
+		t.Fatalf("association join workaround failed: %v", err)
+	}
+	if workaround.Customer.Name != "tenant customer" {
+		t.Fatalf("association join workaround got customer %q, want %q", workaround.Customer.Name, "tenant customer")
 	}
 }
 
-// func TestGORMGen(t *testing.T) {
-// 	user := models.User{Name: "jinzhu2"}
-// 	ctx := context.Background()
+func mustExec(t *testing.T, query string) {
+	t.Helper()
 
-// 	gorm.G[models.User](DB).Create(ctx, &user)
-
-// 	if u, err := gorm.G[models.User](DB).Where(g.User.ID.Eq(user.ID)).First(ctx); err != nil {
-// 		t.Errorf("Failed, got error: %v", err)
-// 	} else if u.Name != user.Name {
-// 		t.Errorf("Failed, got user name: %v", u.Name)
-// 	}
-// }
+	if err := DB.Exec(query).Error; err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}


### PR DESCRIPTION
This playground case demonstrates that Generics API association joins use the relation schema table for the joined table even when the root table is schema-qualified.\n\nThe test also shows the current workaround: using AssociationFrom with a SELECT subquery against the schema-qualified table.