### PR TITLE
Postgres Index Drop/Alter failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: go mod pakcage cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.mod') }}
@@ -114,7 +114,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: go mod pakcage cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.mod') }}
@@ -158,7 +158,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: go mod pakcage cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.mod') }}

--- a/go.mod
+++ b/go.mod
@@ -1,41 +1,37 @@
 module gorm.io/playground
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.26.0
 
 require (
+	github.com/stretchr/testify v1.12.1
 	gorm.io/driver/mysql v1.6.0
-	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/postgres v1.6.2
 	gorm.io/driver/sqlite v1.6.0
-	gorm.io/driver/sqlserver v1.6.1
-	gorm.io/gorm v1.30.1
+	gorm.io/driver/sqlserver v1.6.4
+	gorm.io/gorm v1.31.2
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.3 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
+	github.com/go-sql-driver/mysql v1.10.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.5 // indirect
+	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/microsoft/go-mssqldb v1.9.2 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
-	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/tools v0.36.0 // indirect
-	gorm.io/cmd/gorm v0.1.1-0.20250825094947-30e7d4fa1f1f // indirect
-	gorm.io/datatypes v1.2.5 // indirect
-	gorm.io/hints v1.1.2 // indirect
-	gorm.io/plugin/dbresolver v1.6.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.52 // indirect
+	github.com/microsoft/go-mssqldb v1.11.0 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 )
 
 replace gorm.io/gorm => ./gorm
+
+// replace gorm.io/driver/postgres => ../postgres

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gorm.io/gorm"
 	"gorm.io/playground/models"
 )
 
@@ -11,14 +16,137 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver
 
 func TestGORM(t *testing.T) {
-	user := models.User{Name: "jinzhu"}
-
-	DB.Create(&user)
-
-	var result models.User
-	if err := DB.First(&result, user.ID).Error; err != nil {
-		t.Errorf("Failed, got error: %v", err)
+	if strings.ToLower(DB.Name()) != "postgres" {
+		t.Skip("Only runs on Postgres")
 	}
+	t.Run("DropIndexByField", func(t *testing.T) {
+		assert.NoError(t, DB.Migrator().DropIndex(&models.User{}, "Name"))
+		assert.False(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		t.Cleanup(func() {
+			require.NoError(t, DB.AutoMigrate(&models.User{}))
+			assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		})
+	})
+	t.Run("DropIndexByName", func(t *testing.T) {
+		assert.NoError(t, DB.Migrator().DropIndex(&models.User{}, "idx_name"))
+		assert.False(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		t.Cleanup(func() {
+			require.NoError(t, DB.AutoMigrate(&models.User{}))
+			assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		})
+	})
+	t.Run("RenameIndexByField", func(t *testing.T) {
+		t.Skip("Although documented https://gorm.io/docs/migration.html#Indexes this DOES NOT WORK!")
+		// Do not do the following, as there is a column Name2, and it will be chosen when trying to find the index!
+		// assert.NoError(t, DB.Migrator().RenameIndex(&models.User{}, "Name", "Name2"))
+		assert.NoError(t, DB.Migrator().RenameIndex(&models.User{}, "Name", "idx_name2"))
+		assert.False(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		assert.True(t, DB.Migrator().HasIndex(&models.User{}, "idx_name2"))      // Have to use the real name.  Name2 will resolve to the index on the Name2 column
+		require.NoError(t, DB.Migrator().DropIndex(&models.User{}, "idx_name2")) // Have to use the real name.  Name2 will resolve to the index on the Name2 column
+		assert.False(t, DB.Migrator().HasIndex(&models.User{}, "idx_name2"))     // Have to use the real name.  Name2 will resolve to the index on the Name2 column
+		t.Cleanup(func() {
+			require.NoError(t, DB.AutoMigrate(&models.User{}))
+			assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		})
+	})
+	t.Run("RenameIndexByFieldToExisting", func(t *testing.T) {
+		t.Skip("Although documented https://gorm.io/docs/migration.html#Indexes this DOES NOT WORK!")
+		err := DB.Migrator().RenameIndex(&models.User{}, "Name", "idx_name_2") // Attempt to rename to an existing index name (on Name2)
+		if !assert.Error(t, err) {
+			t.Fatal()
+		}
+		assert.Contains(t, err.Error(), "failed to rename index")
+		assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name2"))
+		assert.True(t, DB.Migrator().HasIndex(&models.User{}, "idx_name_2"))
+	})
+	t.Run("RenameIndexByName", func(t *testing.T) {
+		assert.NoError(t, DB.Migrator().RenameIndex(&models.User{}, "idx_name", "idx_name2"))
+		assert.False(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name2"))
+		t.Cleanup(func() {
+			require.NoError(t, DB.AutoMigrate(&models.User{}))
+			assert.True(t, DB.Migrator().HasIndex(&models.User{}, "Name"))
+		})
+	})
+	t.Run("TestWhatHappensWithSchemas", func(t *testing.T) {
+		assert.NoError(t, DB.Migrator().AutoMigrate(&PublicSchema{}))
+		// CREATE TABLE "public"."public_schema" ("id" bigserial,"created_at" timestamptz,"updated_at" timestamptz,"deleted_at" timestamptz,"std_column" text,PRIMARY KEY ("id"))
+		assert.NoError(t, DB.Migrator().DropIndex(&PublicSchema{}, "StdColumn"))
+		// DROP INDEX "public"."idx_public_public_schema_std_column"
+		assert.NoError(t, DB.Migrator().CreateIndex(&PublicSchema{}, "StdColumn"))
+		// CREATE INDEX IF NOT EXISTS "idx_public_public_schema_std_column" ON "public"."public_schema" ("std_column")
+		assert.NoError(t, DB.Migrator().RenameIndex(&PublicSchema{}, "idx_public_public_schema_std_column", "idx_public_public_schema_std_column2"))
+		// ALTER INDEX "public"."idx_public_public_schema_std_column" RENAME TO "idx_public_public_schema_std_column2"
+		assert.NoError(t, DB.Migrator().RenameIndex(&PublicSchema{}, "idx_public_public_schema_std_column2", "idx_public_public_schema_std_column"))
+		// ALTER INDEX "public"."idx_public_public_schema_std_column2" RENAME TO "idx_public_public_schema_std_column"
+		assert.Error(t, DB.Migrator().AutoMigrate(&DotSchema{}))
+		// CREATE TABLE "."dot_schema" ("id" bigserial,"created_at" timestamptz,"updated_at" timestamptz,"deleted_at" timestamptz,"std_column" text,PRIMARY KEY ("id")) // ERROR: syntax error at or near "dot_schema" (SQLSTATE 42601)
+		require.NoError(t, DB.Exec("set search_path = ''").Error)
+		// set search_path = ''
+		require.Error(t, DB.Migrator().AutoMigrate(&NoSchema{}))
+		// CREATE TABLE "no_schema" ("id" bigserial,"created_at" timestamptz,"updated_at" timestamptz,"deleted_at" timestamptz,"std_column" text,PRIMARY KEY ("id")) // ERROR: no schema has been selected to create in (SQLSTATE 3F000)
+		require.NoError(t, DB.Exec("set search_path = DEFAULT").Error)
+		// set search_path = DEFAULT
+		require.NoError(t, DB.Migrator().AutoMigrate(&NoSchema{}))
+		// CREATE TABLE "no_schema" ("id" bigserial,"created_at" timestamptz,"updated_at" timestamptz,"deleted_at" timestamptz,"std_column" text,PRIMARY KEY ("id"))
+		assert.NoError(t, DB.Migrator().DropIndex(&NoSchema{}, "StdColumn"))
+		// DROP INDEX "public"."idx_no_schema_std_column"
+		assert.NoError(t, DB.Migrator().CreateIndex(&NoSchema{}, "StdColumn"))
+		// CREATE INDEX IF NOT EXISTS "idx_no_schema_std_column" ON "no_schema" ("std_column")
+		assert.NoError(t, DB.Migrator().RenameIndex(&NoSchema{}, "idx_no_schema_std_column", "idx_no_schema_std_column2"))
+		// ALTER INDEX "public"."idx_no_schema_std_column" RENAME TO "idx_no_schema_std_column2"
+		assert.NoError(t, DB.Migrator().RenameIndex(&NoSchema{}, "idx_no_schema_std_column2", "idx_no_schema_std_column"))
+		// ALTER INDEX "public"."idx_no_schema_std_column2" RENAME TO "idx_no_schema_std_column"
+		require.NoError(t, DB.Exec("set search_path = ''").Error)
+		// set search_path = ''
+		assert.Error(t, DB.Migrator().DropIndex(&NoSchema{}, "StdColumn"))
+		// DROP INDEX "idx_no_schema_std_column" // ERROR: index "idx_no_schema_std_column" does not exist (SQLSTATE 42704)
+		require.NoError(t, DB.Exec("set search_path = DEFAULT").Error)
+		// set search_path = DEFAULT
+		assert.NoError(t, DB.Migrator().DropIndex(&NoSchema{}, "StdColumn"))
+		// DROP INDEX "public"."idx_no_schema_std_column"
+		t.Cleanup(func() {
+			if DB.Migrator().HasTable(&PublicSchema{}) { // SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'public_schema' AND table_type = 'BASE TABLE'
+				require.NoError(t, DB.Migrator().DropTable(&PublicSchema{}))
+				// DROP TABLE IF EXISTS "public"."public_schema" CASCADE
+			}
+			if DB.Migrator().HasTable(&NoSchema{}) { // SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'no_schema' AND table_type = 'BASE TABLE'
+				require.NoError(t, DB.Migrator().DropTable(&NoSchema{}))
+				// DROP TABLE IF EXISTS "no_schema" CASCADE
+			}
+			if DB.Migrator().HasTable(&DotSchema{}) { // SELECT count(*) FROM information_schema.tables WHERE table_schema = '' AND table_name = 'dot_schema' AND table_type = 'BASE TABLE'
+				require.NoError(t, DB.Migrator().DropTable(&DotSchema{}))
+			}
+		})
+	})
+}
+
+type NoSchema struct {
+	gorm.Model
+	StdColumn string `gorm:"index"`
+}
+
+func (t *NoSchema) TableName() string {
+	return "no_schema"
+}
+
+type DotSchema struct {
+	gorm.Model
+	StdColumn string `gorm:"index"`
+}
+
+func (t *DotSchema) TableName() string {
+	return ".dot_schema"
+}
+
+type PublicSchema struct {
+	gorm.Model
+	StdColumn string `gorm:"index"`
+}
+
+func (t *PublicSchema) TableName() string {
+	return "public.public_schema"
 }
 
 // func TestGORMGen(t *testing.T) {

--- a/models/models.go
+++ b/models/models.go
@@ -13,7 +13,8 @@ import (
 // His pet also has one Toy (has one - polymorphic)
 type User struct {
 	gorm.Model
-	Name      string
+	Name      string `gorm:"size:255;index:idx_name,unique"`
+	Name2     string `gorm:"size:255;index:idx_name_2,unique"`
 	Age       uint
 	Birthday  *time.Time
 	Account   Account


### PR DESCRIPTION
## Explain your user case and expected results
As a developer I want to be able to drop indexes within a Postgres database using code as per the TestMigrateIndexes gorm testing function, without syntax errors being thrown:
```
	if err := DB.Migrator().DropIndex(&IndexStruct{}, "Name"); err != nil {
		t.Fatalf("Failed to drop index for user's name, got err %v", err)
	}
```

As a developer I want to be able to rename indexes within a Postgres database using code as per the TestMigrateIndexes gorm testing function, without syntax errors being thrown:
```
	if err := DB.Migrator().RenameIndex(&IndexStruct{}, "idx_index_structs_name", "idx_users_name_1"); err != nil {
		t.Fatalf("no error should happen when rename index, but got %v", err)
	}
```

This PR will fail using Postgres driver versions v1.6.1 or v1.6.2.